### PR TITLE
Add catalan translation

### DIFF
--- a/peazip-sources/res/lang-wincontext/ca.reg
+++ b/peazip-sources/res/lang-wincontext/ca.reg
@@ -1,0 +1,76 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate] 
+@="Afegeix a un fitxer"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatesingle]
+@="Afegeix a fitxers separats"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7z]
+@="Afegeix a un 7Z"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zfastest]
+@="Afegeix a un 7Z, més ràpid"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7znormal]
+@="Afegeix a un 7Z, normal"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zultra]
+@="Afegeix a un 7Z, ultra ràpid"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zencrypt]
+@="Encripta (7Z)"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezip]
+@="Afegeix a un ZIP"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipfastest]
+@="Afegeix a un ZIP, més ràpid"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipnormal]
+@="Afegeix a un ZIP, normal"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipultra]
+@="Afegeix a un ZIP, ultra ràpid"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipmail]
+@="Comprimeix i envia per e-mail"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatesfx]
+@="Afegeix a un arxiu auto-extraïble"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2browseasarchive]
+@="Obre com a document"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2browsepath]
+@="Navega pel directori amb el PeaZip"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2split]
+@="Divideix el fitxer"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2convert] 
+@="Converteix a un altre format"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2wipe]
+@="Elimina amb seguretat"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2here]
+@="Extreu aquí"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2smart]
+@="Extreu aquí (nova carpeta intel·ligent)"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2folder]
+@="Extreu aquí (en una nova carpeta)"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2main]
+@="Extreu..."
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2a]
+@="Extreu els arxius"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2test]
+@="Verifica els arxius"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.analyze]
+@="CRC, hash i eines de fitxers"

--- a/peazip-sources/res/lang-wincontext/ca.reg
+++ b/peazip-sources/res/lang-wincontext/ca.reg
@@ -58,7 +58,7 @@ Windows Registry Editor Version 5.00
 @="Extreu aquí"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2smart]
-@="Extreu aquí­ (nova carpeta intel·ligent)"
+@="Extreu aquí (nova carpeta intel·ligent)"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2folder]
 @="Extreu aquí­ (en una nova carpeta)"

--- a/peazip-sources/res/lang-wincontext/ca.reg
+++ b/peazip-sources/res/lang-wincontext/ca.reg
@@ -10,13 +10,13 @@ Windows Registry Editor Version 5.00
 @="Afegeix a un 7Z"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zfastest]
-@="Afegeix a un 7Z, m√©s r√†pid"
+@="Afegeix a un 7Z, mÈs r‡pid"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7znormal]
 @="Afegeix a un 7Z, normal"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zultra]
-@="Afegeix a un 7Z, ultra r√†pid"
+@="Afegeix a un 7Z, ultra r‡pid"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zencrypt]
 @="Encripta (7Z)"
@@ -25,19 +25,19 @@ Windows Registry Editor Version 5.00
 @="Afegeix a un ZIP"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipfastest]
-@="Afegeix a un ZIP, m√©s r√†pid"
+@="Afegeix a un ZIP, mÈs r‡pid"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipnormal]
 @="Afegeix a un ZIP, normal"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipultra]
-@="Afegeix a un ZIP, ultra r√†pid"
+@="Afegeix a un ZIP, ultra r‡pid"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipmail]
 @="Comprimeix i envia per e-mail"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatesfx]
-@="Afegeix a un arxiu auto-extra√Øble"
+@="Afegeix a un arxiu auto-extraÔble"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2browseasarchive]
 @="Obre com a document"
@@ -55,13 +55,13 @@ Windows Registry Editor Version 5.00
 @="Elimina amb seguretat"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2here]
-@="Extreu aqu√≠"
+@="Extreu aquÌ"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2smart]
-@="Extreu aqu√≠ (nova carpeta intel¬∑ligent)"
+@="Extreu aquÌ≠ (nova carpeta intel∑ligent)"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2folder]
-@="Extreu aqu√≠ (en una nova carpeta)"
+@="Extreu aquÌ≠ (en una nova carpeta)"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2main]
 @="Extreu..."

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -368,7 +368,7 @@ txt_4_5_shaddress: Mostra la barra d'adreça
 txt_4_5_shnav: Mostra la barra de navegació
 txt_4_5_shstatus: Mostra la barra d'estat
 txt_4_5_shtool: Mostra la barra d'eines
-txt_4_5_upxpj: Em sap greu, no es pot exportar la definició de la tasca, ja que aquesta acció o opció requereix executar múltiples comandes diferents
+txt_4_5_upxpj: Em sap greu, no es pot exportar la definició de la tasca, ja que aquesta acció o opció requereix executar múltiples ordres diferents
 txt_4_5_t: Part superior
 txt_4_4_confremoveall: Vols eliminar tots els fitxers personalitzats del PeaZip (Aplicacions, Preferits, Administrador de contrasenyes)?
 txt_4_4_confremove: Vols eliminar la configuració del PeaZip?
@@ -497,8 +497,8 @@ txt_2_7_extfrom: Extraient de l'arxiu:
 txt_2_7_es: Extreu els tipus de fitxers compatibles que no són comprimits, p. ex. executables, MS Office i fitxers OOo
 txt_2_7_eu: Extreu tipus de fitxers no suportats, especificant una utilitat d'extracció personalitzada
 txt_2_7_clipboard: Porta-retalls
-txt_2_7_goarclayout: Ves a la maquetació de compressió
-txt_2_7_goextlayout: Ves a la maquetació d'extracció
+txt_2_7_goarclayout: Vés a la maquetació de compressió
+txt_2_7_goextlayout: Vés a la maquetació d'extracció
 txt_2_7_ok: OK
 txt_2_7_drag_archive: vols obrir el fitxer com a nou arxiu? (clica "No" per afegir el fitxer a la finestra actual d'arxivament)
 txt_2_7_oop: Obra la ubicació d'extracció quan finalitzi el procés
@@ -533,23 +533,23 @@ txt_2_5_encpj: Encode task definition as UTF-8 text
 txt_2_5_execommand: Executable or command
 txt_2_5_help: Ajuda
 txt_2_5_langhint: Hint: replacing extended characters with "?" jolly character can improve syntax if archive's character set cannot be successfully converted on the current machine
-txt_2_5_mini_help: Localized Tutorial
+txt_2_5_mini_help: Tutorial en el teu idioma
 txt_2_5_offline_help: Ajuda del PeaZip
-txt_2_5_tray: Reduce to tray
-txt_2_5_remove: Remove
-txt_2_5_hintpaths: Rightclick to open system's and user's paths
-txt_2_5_selectapp: Select application
-txt_2_5_strafter: String after input name
-txt_2_5_strbefore: String before input name
+txt_2_5_tray: Minimitza a la safata del sistema
+txt_2_5_remove: Elimina
+txt_2_5_hintpaths: Fes clic amb el botó de la dreta per per obrir les rutes del sistema y de l'usuari
+txt_2_5_selectapp: Selecciona una aplicació
+txt_2_5_strafter: Cadena alfanumèrica després del nom d'entrada
+txt_2_5_strbefore: Cadena alfanumèrica abans del nom d'entrada
 txt_2_5_encoding: Codificació del text
-txt_2_5_nopw: this type of archives does not support encryption
+txt_2_5_nopw: aquest tipus d'arxius no suporten l'encriptació
 txt_2_4_draghint: [drag to Explorer with enabled Address bar]
-txt_2_4_tb: Adapt toolbar buttons (restarts PeaZip)
+txt_2_4_tb: Adapta els botons de la barra d'eines (requereix reiniciar el PeaZip)
 txt_2_4_adding: Afegint
-txt_2_4_advclip: Clipboard keeps multiple selections
+txt_2_4_advclip: Desar diverses seleccions al porta-retalls, es neteja en enganxar
 txt_2_4_yanswers: Answers
-txt_2_4_itemsheight: Auto-size items height
-txt_2_4_clearclipboard: Clear clipboard (Esc)
+txt_2_4_itemsheight: Redimensiona l'altura dels elements
+txt_2_4_clearclipboard: Neteja el porta-retalls (Esc)
 txt_2_4_wcommons: Commons
 txt_2_4_copyfrom: Copia desde
 txt_2_4_deletebookmarks: Do you want to delete the list of bookmarked files and folders?
@@ -568,15 +568,15 @@ txt_2_4_wnews: Wikinews
 txt_2_4_wsrc: Wikisource
 txt_2_4_wdict: Wiktionary
 txt_2_3_pw_errorchar: quote character is not recommended to be used in passwords (for PeaZip and scripts). If you need to create or extract an archive with this password you can dismiss the message and you will be asked to enter the password interactively in console.
-txt_2_3_envstr: Display environment variables
-txt_2_3_never_pw: Don't ask for password
+txt_2_3_envstr: Mostra les variables d'entorn
+txt_2_3_never_pw: No demanis cap contrasenya
 txt_2_3_home: Directori de l'usuari
-txt_2_3_on_pw: On extract/list/test operations from system's menus:
-txt_2_3_test_pw100: Test for encryption <100MB archives
-txt_2_3_test_pw: Test for encryption (may be slow)
-txt_exclude_recourse: "exclude" recurse subdirs
-txt_action_extopen: "Extract and open with associated application" action
-txt_error_passwordnotmatch: "Password" and "Confirm" fields doesn't match, please correct them
+txt_2_3_on_pw: Quan s'executin operacions d'extracció, llistat o verificació des dels menús del sistema:
+txt_2_3_test_pw100: Verifica si es poden encriptar, arxius <100MB
+txt_2_3_test_pw: Verifica si es poden encriptar (pot ser un procés lent)
+txt_exclude_recourse: Recursiu (explou les subcarpetes)
+txt_action_extopen: Acció de "Extreu i obre amb l'aplicació associada del sistema"
+txt_error_passwordnotmatch: Els camps de contrasenya i confirmació de la contrasenya no coincideixen, si us plau, corregeir-los
 txt_action_preview: "Preview with associated application" action
 txt_preview_hint: "Preview" action perform the same task as "Extract and open" but to a temporary path in output directory, automatically removed when the archive is closed.
 txt_better: (millor)
@@ -590,17 +590,17 @@ txt_store: (store, fastest)
 txt_newfolder: (en una carpeta nova)
 txt_7z_exitcodeunknown: : Error de tasca desconegut
 txt_list_isfolder:  [carpeta]
-txt_none: <none>
+txt_none: <cap>
 txt_fd: 1.44 MB Disquet
 txt_7z_exitcode1: 1: Warning: non fatal error(s); i.e. some files missing or locked
 txt_attach10: adjunt de 10 MB
-txt_7z_exitcode2: 2: Fatal error occurred
-txt_7z_exitcode255: 255: Task halted by the user
+txt_7z_exitcode2: 2: S'ha produït un error fatal
+txt_7z_exitcode255: 255: L'usuari ha interromput la tasca
 txt_fat32: 4 GB Fitxer FAT32
 txt_dvd: 4.7 GB DVD
 txt_attach5: adjunt de 5 MB
 txt_cd650: 650 MB CD
-txt_7z_exitcode7: 7: Error: got incorrect command line
+txt_7z_exitcode7: 7: Error: s'ha obtingut una ordre incorrecta
 txt_cd700: 700 MB CD
 txt_type_description_7z: 7Z: feature rich archive format with high compression ratio
 txt_dvddl: 8.5 GB DVD DL
@@ -668,42 +668,42 @@ txt_archive_root: Browsing: archive's root
 txt_type_description_bzip2: BZip2: quite powerful compression, average speed
 txt_pw_empty: Please provide a password (or a keyfile)
 txt_add_error: Cannot add/update or delete object(s). The archive is not writeable, or cannot support this operation. Editing non-canonical archive types can be enabled in Archive manager options.
-txt_un7z_browse_failure: cannot browse archive
+txt_un7z_browse_failure: no es pot navegar per l'arxiu
 txt_list_error: Cannot list archive's content, please check if the archive is password protected or corrupted.
 txt_conf_cannotsave: Cannot save configuration file, check if the path is writeable and with some free space
 txt_check_hint: Check for casual data corruption; hash algorithms are suitable to detect even malicious data tampering (see the documentation)
 txt_check: Checksum/hash file(s)
-txt_check_select: Checksum/hash
+txt_check_select: Suma de comprovació/hash
 txt_clear: Neteja
-txt_clearlayout: Neteja la maquetació
+txt_clearlayout: Neteja el resultat
 txt_pj_hint: Click to import task, reset changes and load up to date task definition from GUI
 txt_autoclose: Close PeaLauncher when task completes
 txt_cl: línia de comandes:
 txt_compare: Compara els fitxers
 txt_compress: Comprimeix
-txt_compress_executable: Compress executable
-txt_compress_openforwriting: Compress files open for writing
+txt_compress_executable: Comprimeix com a executable
+txt_compress_openforwriting: Comprimeix fitxers oberts per a escriptura
 txt_compression: Compressió
-txt_compmanagement: Computer management
-txt_pw_confirm: Confirma
+txt_compmanagement: Administració del sistema
+txt_pw_confirm: Confirmació de la contrasenya
 txt_console: Consola
-txt_console_interface: Console: native interface
+txt_console_interface: Consola: interfície nativa
 txt_content: Contingut
 txt_controlpanel: Control panel
-txt_convert: Convert disk to NTFS
+txt_convert: Converteix el disc a NTFS
 txt_copy: Copia
 txt_copyto: Copia a...
-txt_create: Create
-txt_create_archive: Create new archive
-txt_title_create: Create archive, compress, encrypt, split...
+txt_create: Nou
+txt_create_archive: Crea un nou arxiu
+txt_title_create: Crea un nou arxiu, comprimeix-lo, encripta'l, divideix-lo...
 txt_create_keyfile: Crea un fitxer de xifratge
-txt_create_folder: Create new folder
-txt_create_theme: Create Theme from current settings
-txt_rr: Create recovery records
-txt_create_sfx: Create self-extracting archive
-txt_cr_current: Current path or filter compression ratio
+txt_create_folder: Crea una nova carpeta
+txt_create_theme: Crea un Tema amb la configuració actual
+txt_rr: Crea una recuperació de registres
+txt_create_sfx: Crea un arxiu auto-extraïble
+txt_cr_current: Ruta actual o ràtio de compressió del filtre
 txt_custom: Personalitzat
-txt_type_description_custom: Custom (advanced users): enter executable name and parameters
+txt_type_description_custom: Personalitzat (usuaris experts): introdueix el nom de l'executable i altres paràmetres
 txt_customapp: Aplicació personalitzada
 txt_custom_parameters: Paràmetres personalitzats
 txt_customsize: Mida personalitzada
@@ -713,31 +713,31 @@ txt_default: per defecte
 txt_default_compression: compressió per defecte
 txt_default_format: Format per defecte
 txt_theme_default: Tema per defecte
-txt_hard_reset_hint: Delete bookmarks file
+txt_hard_reset_hint: Elimina el fitxer de marcadors
 txt_desktop: Escriptori
 txt_dictionary: Diccionari
-txt_dirs: dir(s),
+txt_dirs: carpetes,
 txt_dis: Disambiguation:
-txt_disk_cleanup: Disk cleanup
-txt_disk_defrag: Disk defrag
-txt_disk_management: Disk management
-txt_dispaly: Display results as
-txt_displayedmnu_obj: displayed
-txt_displayedobjects: Displayed objects
+txt_disk_cleanup: Neteja del disc
+txt_disk_defrag: Desfragmentació del disc
+txt_disk_management: Administració del disc
+txt_dispaly: Mostra els resultats com a
+txt_displayedmnu_obj: mostrats
+txt_displayedobjects: Objectes mostrats
 txt_nocompress: no comprimeixis
 txt_delete: Do you want to delete selected file(s)? The operation can't be undone and files will be not recoverable from recycle bin
 txt_wipe: Do you want to securely delete selected file(s)? The operation can't be undone and files will be not recoverable
 txt_done: Fet
 txt_edit: Edita
-txt_elapsed: elapsed:
+txt_elapsed: transcorregut:
 txt_error_emptycl: Empty command line!
 txt_encrypt: Encripta
 txt_encrypted: encriptat
 txt_encryption: Encriptació
-txt_note: Enter note / description
-txt_random_keys: Enter random keys
-txt_random_keys_hint: Enter random keys (you not have to remember)
-txt_ent: Entropy evaluation
+txt_note: Introdueix una nota o descripció
+txt_random_keys: Introdueix claus aleatòries
+txt_random_keys_hint: Introdueix claus aleatòries (no cal que les recordis més endavant)
+txt_ent: Avaluació de l'entropia
 txt_ent_tools: Move the mouse or use additional entropy sampling tools
 txt_eqorlarger: Igual o més gran que el fitxer seleccionat
 txt_eqorrecent: Igual o més recent que el fitxer seleccionat
@@ -776,10 +776,10 @@ txt_level_fast: Ràpid
 txt_fastcompr: compressió ràpida
 txt_fastopen: Fast open routine, stop browsing extremely large archives, use filters instead
 txt_level_fastest: Més ràpid
-txt_favformats: Favorite formats shortcuts
+txt_favformats: Formats preferits
 txt_file: Fitxer
-txt_filebrowser: File browser / archive browser
-txt_filetools: File tools
+txt_filebrowser: Explorador de fitxers
+txt_filetools: Eines de fitxers
 txt_files: fitxer(s),
 txt_nfiles: Fitxers
 txt_fs: Sistema de fitxers
@@ -787,7 +787,7 @@ txt_filters_recourse: filter(s) recurse subdirs
 txt_filters: Filtres
 txt_flat: Pla (mostra-ho tot)
 txt_list_flat: Vista plana
-txt_unit_floppy: Floppy disk
+txt_unit_floppy: Disquet
 txt_foldername: Nom de la carpeta
 txt_nfolders: Carpetes
 txt_error_input_multi: format allows a single file as input; you can use "TAR before" switch to save input in a .TAR archive before, otherwise you can chose another format. HINT: chose archive format after had selected input data: "TAR before" switch will be automatically set
@@ -799,8 +799,8 @@ txt_name_full: Nom complet
 txt_function: Funció
 txt_general: General
 txt_multithreading: Generic multithreading
-txt_go_browser: Go to file browser
-txt_go_path: Explore path (PeaZip)
+txt_go_browser: Vés a l'explorador de fitxers
+txt_go_path: Explora la ruta (PeaZip)
 txt_guicl: Graphic + console
 txt_guipealauncher: Graphic: wrapped by PeaLauncher
 txt_graphic: Graphic's folder
@@ -828,22 +828,22 @@ txt_inputinfo: Input information
 txt_input_list: Input list:
 txt_iop: input, output, parameters
 txt_ipo: input, parameters, output
-txt_input: input:
-txt_integrity: Integrity check
+txt_input: entrada:
+txt_integrity: Verifica la integritat
 txt_chunk_size: Invalid custom size, please correct it in a numerical value
-txt_invertsel: Invert selection
+txt_invertsel: Inverteix la selecció
 txt_type_exe: is a Windows executable, do you want to run it? ("No" to try open it as archive) HINT: some executables may not properly run unless the whole archive is extracted before
 txt_return_to_archive: is currently open; do you want to browse it?
-txt_not_accessible: is no longer accessible
-txt_type_unsupported: is not a supported archive type
-txt_checkname_failed: is not a valid name.
+txt_not_accessible: ja no és accessible
+txt_type_unsupported: no és un format d'arxiu suportat
+txt_checkname_failed: no és un nom vàlid.
 txt_not_accessible_list: is not accessible, please check if the file list provided is correct and up to date
 txt_theme_create_error: It was not possible to create the theme, try to use a name valid for a folder as theme name and to chose a writeable path
 txt_theme_exists: yet exists, please provide a different path
-txt_job_code: task code:
+txt_job_code: codi de tasca:
 txt_job_definition_saved: Task definition successfully saved in
-txt_job_success: Task successfully completed!
-txt_join: Join
+txt_job_success: La tasca s'ha completat satisfactòriament!
+txt_join: Uneix
 txt_joinfiles: Join files
 txt_keyfile: Fitxer de xifratge
 txt_keyfile_not_found: Keyfile cannot be found or read. Please chose a different Keyfile.
@@ -1137,7 +1137,7 @@ txt_3_0_arc: Some input files cannot be read (may be locked, not accessible or c
 txt_3_0_ext: The archive may require a different password for the current operation
 txt_2_8_oop: Obre l'ubicació de sortida quan finalitzi la tasca
 txt_2_7_validatefn: S'ha aturat l’operació, s'ha detectat un nom de fitxer invàlid:
-txt_2_7_validatecl: S'ha aturat l’operació, s'ha detectat una comanda potencialment perillosa (p. ex. comandes concatenades no permeses al programa):
+txt_2_7_validatecl: S'ha aturat l’operació, s'ha detectat una ordre potencialment perillosa (p. ex. ordres concatenades no permeses al programa):
 txt_2_6_open: Obre un arxiu
 txt_2_5_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
 txt_2_3_pw_errorchar_gwrap: quote character cannot be used by PeaLauncher in passwords under current system, please change password or chose Console mode in Backend binaries user interface in Options > Settings
@@ -1163,7 +1163,7 @@ txt_job1: 1: Avís: s'han produït errors lleus; p. ex. no s'han trobat alguns f
 txt_job127: 127: No s'ha pogut executar la operació sol·licitada
 txt_job2: 2: Error fatal
 txt_job255: 255: Tasca interrompuda per l'usuari
-txt_job7: 7: Error: línia de comandes incorrecta
+txt_job7: 7: Error: ordre incorrecta
 txt_job8: 8: Error: no hi ha prou memòria per a la operació sol·licitada
 txt_autoclose: Tanca la finestra quan finalitzi la tasca
 txt_crscale: Ràtio de compressió (com més baixa, millor):
@@ -1171,7 +1171,7 @@ txt_console: Consola
 txt_benchscale: Evaluació Core 2 Duo 6600, equivalent a la velocitat de MHz.
 txt_create: Crea
 txt_done: Fet:
-txt_nocl: Buida la línia de comandes
+txt_nocl: Neteja la línia de comandes
 txt_error: Error:
 txt_explore: Explora
 txt_extto: Extreu a

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -67,7 +67,7 @@ txt_7_6_forceutf8enc: Força'l UTF-8
 txt_7_6_cpnote: Si la pàgina de codis personalitzats escollida no és compatible, les tasques acabaran sempre amb un error (probablement, un error d'assignació de memòria). En cas que això passi, canvieu la pàgina de codis o restabliu l'aplicació.
 txt_7_6_defaultenc: Local, UTF-8 per a símbols addicionals
 txt_7_6_dim: Clar
-txt_7_6_setcurdef: Estableix la ubicació actual com a ubicació d'extracció per defecte
+txt_7_6_setcurdef: Estableix l'ubicació actual com a ubicació d'extracció per defecte
 txt_7_6_setdef: Estableix una ubicació d'extracció per defecte
 txt_7_6_tadvanced: Sincronitza l'arbre de l'arxiu, manté els elements visitats
 txt_7_6_tsimple: Sincronitza l'arbre de l'arxiu, simple
@@ -86,112 +86,112 @@ txt_7_5_draglock: Bloqueja el destí
 txt_7_5_never: Mai
 txt_7_5_repnascii: Substitueix / elimina caràcters que no siguin ASCII
 txt_7_4_comment: Comenta
-txt_7_4_7zfbrotlicomp: Fastest compression, 7Z Brotli
-txt_7_4_7zfzstandardcomp: Fastest compression, 7Z Zstandard
-txt_7_4_presetrar: High compression, RAR
-txt_7_4_tkeep: Keep original archive timestamp
-txt_7_4_lock: Lock archive
-txt_7_4_locked: locked
-txt_7_4_lockconfirm: Locked archives cannot be further modified, proceed locking this archive?
+txt_7_4_7zfbrotlicomp: Compressió molt ràpida, 7Z Brotli
+txt_7_4_7zfzstandardcomp: Compressió molt ràpida, 7Z Zstandard
+txt_7_4_presetrar: Compressió alta, RAR
+txt_7_4_tkeep: Manté la marca horària de l'arxiu original
+txt_7_4_lock: Bloqueja l'arxiu
+txt_7_4_locked: bloquejat
+txt_7_4_lockconfirm: Els fitxers bloquejats no es poden modificar més endavant, vols continuar bloquejant aquest arxiu?
 txt_7_4_recover: Repara l'arxiu
-txt_7_4_tcurr: Set archive timestamp from current system time
-txt_7_4_setarc: Set advanced archiving options
-txt_7_4_setext: Set advanced extraction options
-txt_7_4_swzipx: Switch to zipx extension for non-Deflate zip archives
-txt_7_3_archiveerrors: [archive may contain errors]
-txt_7_3_archiveerrorshint: Archive may not be valid (due missing, corrupted, or out of standard data), it is possible to run Test for detailed information. If archive's table of content is encrypted, password is needed before browsing it.
+txt_7_4_tcurr: Estableix la marca horària de l'arxiu des del rellotge actual del sistema
+txt_7_4_setarc: Estableix opcions avançades d'arxiu
+txt_7_4_setext: Estableix opcions avançades d'extracció
+txt_7_4_swzipx: Canvia a l'extensió zipx per a arxius ZIP no-Deflate
+txt_7_3_archiveerrors: [l'arxiu pot contenir errors]
+txt_7_3_archiveerrorshint: L'arxiu pot no ser vàlid (a causa de dades perdudes, corrompudes o fora dels estàndards), és possible executar la Verificació per obtenir informació més detallada. Si la taula de l'arxiu està encriptada, es requereix una contrasenya abans de poder-hi navegar.
 txt_7_3_clickextall: Fes clic a "Extreu-ho tot" per habilitar-ho
-txt_7_3_noconfdel: Do not ask confirmation for delete after archiving / extraction
-txt_7_3_profile7zfastest: Fast compression, 7Z fastest
-txt_7_3_maxbr: Maximize Brotli compression using more memory (may be incompatible with some extractors)
-txt_7_3_maxzstd: Maximize Zstandard compression using more memory
-txt_7_3_profile7zfast: Medium compression, 7Z fast
-txt_7_3_stl: Set archive timestamp from most recent file
-txt_7_2_altcomp: High compression, ARC
-txt_7_2_clearnoupdate: Clear edited files
-txt_7_2_autoclosepeazip: Close PeaZip when task completes
-txt_7_2_zpaqall: Extract all revisions
-txt_7_2_extcomp: Extreme compression, ZPAQ
-txt_7_2_extcompultra: Extreme compression, ZPAQ ultra
-txt_7_2_fbrotlicomp: Fastest compression, Brotli
-txt_7_2_fzstandardcomp: Fastest compression, Zstandard
-txt_7_2_loadcompsettings: Load compression settings
-txt_7_2_savecompsettings: Save compression settings
-txt_7_2_source: Source
-txt_7_2_updateclear: Update edited files in archive, and clear edited files
-txt_7_1_type_description_brotli: Brotli: fast compressor from Google, very fast decompression
-txt_7_1_new: Extract all here (in new folder)
-txt_7_1_smart: Extract all here (smart new folder)
-txt_7_1_profileintermediate: Medium compression, ZIP/BZip2 fast
-txt_7_1_renfilesonly: Rename only files
-txt_7_1_typetosearch: Type to search in current path
-txt_7_1_type_description_zstd: Zstandard: fast compressor from Facebook, very fast decompression
-txt_7_0_af: Analyze content of folders
-txt_7_0_autoopentar: Auto open single tar archive inside tar.* files
-txt_7_0_exttmppath: Content will be extracted outside the temporary work path, in: 
-txt_6_9_autou: Auto update modified files in archives
-txt_6_9_forceu: Update edited files in archive
-txt_6_9_opuns: Operation not supported for current archive type
-txt_6_9_overarch: Overwrite file(s) with same name already existing inside the archive?
-txt_6_9_uconf: Previewed file has been modified. Update the current archive?
-txt_6_8_ndrop: Use native Drag and Drop on Windows
+txt_7_3_noconfdel: No em demanis confirmació d'eliminació després de l'arxivament o l'extracció
+txt_7_3_profile7zfastest: Compressió ràpida, 7Z més ràpid
+txt_7_3_maxbr: Maximitza la compressió Brotli utilitzant més memòria (pot ser incompatible amb alguns extractors)
+txt_7_3_maxzstd: Maximitza la compressió Zstandard utilitzant més memòria
+txt_7_3_profile7zfast: Compressió mitjana, 7Z ràpid
+txt_7_3_stl: Estableix la marca horària de l'arxiu a partir del fitxer més recent
+txt_7_2_altcomp: Compressió alta, ARC
+txt_7_2_clearnoupdate: Neteja la llista de fitxers editats
+txt_7_2_autoclosepeazip: Tanca el PeaZip quan acabi la tasca
+txt_7_2_zpaqall: Extreu totes les revisions
+txt_7_2_extcomp: Compressió extrema, ZPAQ
+txt_7_2_extcompultra: Compressió extrema, ZPAQ ultra
+txt_7_2_fbrotlicomp: Compressió molt ràpida, Brotli
+txt_7_2_fzstandardcomp: Compressió molt ràpida, Zstandard
+txt_7_2_loadcompsettings: Carrega la configuració de compressió
+txt_7_2_savecompsettings: Desa la configuració de compressió
+txt_7_2_source: Font
+txt_7_2_updateclear: Actualitza els fitxers editats a l'arxiu, i neteja la llista de fitxers editats
+txt_7_1_type_description_brotli: Brotli: compressor ràpid de Google, descompressió molt ràpida
+txt_7_1_new: Extreu-ho tot aquí (en una nova carpeta)
+txt_7_1_smart: Extreu-ho tot aquí (en una nova carpeta intel·ligent)
+txt_7_1_profileintermediate: Compressió mitjana, ZIP/BZip2 ràpid
+txt_7_1_renfilesonly: Reanomena només els fitxers
+txt_7_1_typetosearch: Escriu aquí per cercar dins el directori actual
+txt_7_1_type_description_zstd: Zstandard: compressor ràpid de Facebook, descompressió molt ràpida
+txt_7_0_af: Analitza el contingut de les carpetes
+txt_7_0_autoopentar: Obre automàticament un arxiu tar dins un fitxer tar.*
+txt_7_0_exttmppath: El contingut s'extraurà fora de la carpeta temporal de treball, a: 
+txt_6_9_autou: Actualitza automàticament els fitxers modificats dins d'arxius comprimits
+txt_6_9_forceu: Actualitza els fitxers editats dins l'arxiu comprimit
+txt_6_9_opuns: El tipus d'arxiu no suporta aquesta operació
+txt_6_9_overarch: Vols sobreescriure els fitxers amb el mateix nom que es trobin dins l'arxiu comprimit?
+txt_6_9_uconf: El fitxer previsualitzat ha canviat. Vols actualitzar l'arxiu actual?
+txt_6_8_ndrop: Utilitza l'"arrossega i deixa anar" natiu del Windows
 txt_6_7_nop: (sense previsualització)
 txt_6_6_pdupfound: s'han trobat possibles duplicats (comprovació ràpida aproximada)
 txt_6_6_rsh: Neteja l'historial de cerques
 txt_6_6_pdupfind: Suggereix possibles duplicats
-txt_6_6_forcemodify: Edit non-canonical archive types
+txt_6_6_forcemodify: Modifica tipus d'arxius no canònics
 txt_6_5_mandatory: (obligatori)
 txt_6_5_abort: Avorta
-txt_6_5_askp: Ask to set password at startup
+txt_6_5_askp: Demana'm que defineixi una contrasenya a l'arrancada
 txt_6_5_chp: Canvia la contrasenya
 txt_6_5_def: Definició
-txt_6_5_nop: Don't ask to set password at startup
+txt_6_5_nop: No em demanis que defineixi una contrasenya a l'arrancada
 txt_6_5_error: Error
-txt_6_5_seqerr: Error(s) detected, original files will not be deleted
-txt_6_5_sni: Include NT security information
-txt_6_5_sns: Include NTFS Alternate Data Stream
+txt_6_5_seqerr: Error(s) detectats, no s'eliminaran els fitxers originals
+txt_6_5_sni: Inclou la informació de seguretat NT
+txt_6_5_sns: Inclou NTFS Alternate Data Stream
 txt_6_5_privacy: Privacitat
-txt_6_5_showvolatile: Show which options are volatile / context dependent
-txt_6_5_force: Try to open archives containing errors
+txt_6_5_showvolatile: Mostra quines opcions són volàtils / dependen del context
+txt_6_5_force: Intenta obrir arxius que contenen errors
 txt_6_5_warning: Avís
 txt_6_5_yes: Sí
 txt_6_5_yesall: Sí a tot
-txt_6_5_np: You can now change password of converted archive(s) to a new one, or blank the password to skip encryption
+txt_6_5_np: Ara pots canviar la contrasenya dels arxius convertits per una de nova o deixar-la en blanc per ometre l'encriptació
 txt_6_4_absolute: Camí absolut
-txt_6_4_appdirn: Append directory name
+txt_6_4_appdirn: Afegeix el nom del directori al final
 txt_6_4_closeallother: Tanca totes les altres pestanyes
 txt_6_4_closeright: Tanca totes les pestanyes de la dreta
 txt_6_4_collapse: Comprimeix les pestanyes
 txt_6_4_expand: Expandeix les pestanyes
 txt_6_4_full: Camí complet
-txt_6_4_new: New
+txt_6_4_new: Nou
 txt_6_4_openintab: Obre en una pestanya nova
-txt_6_4_paths: Paths
-txt_6_4_prepdirn: Prepend directory name
+txt_6_4_paths: Rutes
+txt_6_4_prepdirn: Afegeix el nom del directori al principi
 txt_6_4_relative: Camí relatiu
-txt_6_4_tabbar: Tab bar
+txt_6_4_tabbar: Barra de pestanyes
 txt_6_3_autoadjust: Ajusta la columna automàticament
-txt_6_3_cinfo: Info and comments
-txt_6_3_syn: Synchronize archive with disk
-txt_6_3_uar: Update only files already in archive
-txt_6_2_encext: Add ".enc" suffix to encrypted archives
-txt_6_2_archive: Archive file type
-txt_6_2_container: Container file type
-txt_6_1_ec: Expand / collapse archive tree
-txt_6_0_msq: Sort by file type for solid compression
-txt_5_9_lff: Analyze files and folders
-txt_5_9_pff: Analyze, show files header/EOF
+txt_6_3_cinfo: Informació i comentaris
+txt_6_3_syn: Sincronitza l'arxiu amb el disc
+txt_6_3_uar: Actualitza només els fitxers que ja es troben dins l'arxiu
+txt_6_2_encext: Afegeix el sufix ".enc" als arxius encriptats
+txt_6_2_archive: Tipus de fitxer de l'arxiu
+txt_6_2_container: Tipus de fitxer del contenidor
+txt_6_1_ec: Amplia / replega l'arbre de l'arxiu
+txt_6_0_msq: Ordeneu per tipus de fitxer per a una compressió sòlida
+txt_5_9_lff: Analitza fitxers i carpetes
+txt_5_9_pff: Analitza, mostra la capçalera dels fitxers/EOF
 txt_5_9_start: Comença a
-txt_5_8_l0: Allow any supported component/format
-txt_5_8_l1: Allow only Free Software components
-txt_5_8_l2: Allow only open archive formats
+txt_5_8_l0: Permet qualsevol component o format admès
+txt_5_8_l1: Permet només components de programari lliure
+txt_5_8_l2: Permet només formats d'arxiu oberts
 txt_5_8_ascii: ASCII safe, scripts are safe on legacy environments
 txt_5_8_cp: Code Page safe, scripts may trigger problems on legacy environments with different Code Pages
 txt_5_8_fs: Free Software compliance
 txt_5_8_utf: Scripts need full UTF-8 / Unicode environment
 txt_5_8_fsr: This format is not supported due Free Software compliance restrictions (Options > Advanced)
 txt_5_7_pinstalled: INSTAL·LAT
-txt_5_7_pmissing: MISSING
+txt_5_7_pmissing: ABSENT
 txt_5_7_plugin: Plugin missing, can be installed from Help > Check for plugin and addon
 txt_5_6_basic: Basic
 txt_5_6_exarc: Extract archive

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -1,0 +1,1315 @@
+﻿=== PeaZip language file ===
+Catalan - Català
+8.2
+Translated by: Marc Roca Musach
+Last rev. by: Marc Roca Musach
+Last rev.: 20210927
+
+=== PeaZip text group ===
+
+txt_8_2_slower: (més lent)
+txt_8_2_df: 7z / p7zip mostra el contingut de les carpetes
+txt_8_2_vreport: 7z / p7zip non-verbose report
+txt_8_2_ta: Últim accés
+txt_8_2_tc: Creat el
+txt_8_2_keep: Conserva els fitxers
+txt_8_2_tm: Modificat el
+txt_8_2_skipet: Skip testing for encryption
+txt_8_2_alltimes: Emmagatzema totes les marques horàries
+txt_8_2_supportedby: Suportat per
+txt_8_1_preparse: Always pre-parse archives
+txt_8_1_bo: Optimització del navegador
+txt_8_1_bop: Browser optimization options can be set from Options > Settings, General tab, in order to allow browser to display archives containing a very large number of items.
+txt_8_1_nopreparse: Do not pre-parse archives
+txt_8_1_ed: error(s) detectats.
+txt_8_1_togglearc: Listing flat view of archive content may take long time, continue anyway?
+txt_8_1_preparsehint: Optimize performances limiting pre-parsing of large archives. Pre-parsing is meant to detect in advance possible issues in archive content.
+txt_8_1_slow: Lent
+txt_8_1_vslow: Molt lent
+txt_8_1_volumes: volums
+txt_8_0_altcol: Alterna el color de la quadrícula
+txt_8_0_forcebrowse: Browse non-canonical archive types (containers, disk images, installers,...)
+txt_8_0_commonalgo: Algoritmes comuns
+txt_8_0_forceconvert: Convert non-canonical archive types
+txt_8_0_defaultactionhint: Default action double-clicking a file associated with PeaZip from the system
+txt_8_0_defaultaction: Default action on start-up
+txt_8_0_enableextand: Enable "Extract and open with" submenu
+txt_8_0_forcetyping: Force typing passwords interactively
+txt_8_0_setpwopt: Configura les opcions de contrasenya / fitxer-clau
+txt_8_0_forcetypinghelp: Will run backend binaries in console, cannot browse archives with encrypted filenames. Allows to create scripts that will not run unattended but rather ask user interactively for password.
+txt_7_9_spacing: Espaiat
+txt_7_9_zooming: Zooming
+txt_7_8_changelocalization: Canvia l'idioma del PeaZip
+txt_7_8_custext: Extensió personalitzada
+txt_7_8_destexistfile: Destination already contains processed files. Replace files with same name?
+txt_7_8_dd: Drag and Drop
+txt_7_8_priorityhigh: Alta
+txt_7_8_priorityidle: Idle
+txt_7_8_rel: Extracció interactiva
+txt_7_8_prioritynormal: Normal
+txt_7_8_priorityrealtime: En temps real
+txt_7_8_requirerestart: [requereix reiniciar el PeaZip]
+txt_7_8_tpriority: Prioritat de tasques
+txt_7_8_update: Actualitza
+txt_7_7_noneall: None: disable preview, edit, drag&drop and interactive extraction
+txt_7_7_nonetemp: None, user's temp if necessary
+txt_7_7_outtemp: Output, preview in user's temp
+txt_7_7_sys7zreq: Requires p7zip-full or equivalent to be installed
+txt_7_7_tw: Temporary work folder for archive creation, editing, preview and drag&drop extraction
+txt_7_7_sys7z: Use system 7z in Linux
+txt_7_6_zipenc: 7z/p7zip ZIP filenames encoding
+txt_7_6_color: Color
+txt_7_6_custenc: Custom code page
+txt_7_6_dark: Fosc
+txt_7_6_tno: Do not sync archive tree
+txt_7_6_forcelocalenc: Force local
+txt_7_6_forceutf8enc: Force UTF-8
+txt_7_6_cpnote: If the chosen custom code page is unsupported, tasks will always end in error (most likely memory allocation error). In case that happens, change code page or reset the application.
+txt_7_6_defaultenc: Local, UTF-8 for extra symbols
+txt_7_6_dim: Low light
+txt_7_6_setcurdef: Estableix la ubicació actual com a ubicació d'extracció per defecte
+txt_7_6_setdef: Estableix una ubicació d'extracció per defecte
+txt_7_6_tadvanced: Sync archive tree, keep visited nodes
+txt_7_6_tsimple: Sync archive tree, simple
+txt_7_6_tacolor: Text accent
+txt_7_5_always: Sempre
+txt_7_5_ask: Ask
+txt_7_5_autoclosesingle: Auto close after extraction if no browsing actions took place
+txt_7_5_cutlen: Retalla el nom en una longitud determinada
+txt_7_5_cutlenw: Cut name at specified length (4..255) naming conflicts can be fixed manually later
+txt_7_5_dragnone: Do not lock target
+txt_7_5_specialbrowse: Do you want to extract everything in order to provide the file with the extra data it may need?
+txt_7_5_ee: Extract everything for special file types
+txt_7_5_draghide: Hide drop target
+txt_7_5_draglh: Lock and hide target
+txt_7_5_draglock: Lock drop target
+txt_7_5_never: Mai
+txt_7_5_repnascii: Replace/remove non-ASCII characters
+txt_7_4_comment: Comenta
+txt_7_4_7zfbrotlicomp: Fastest compression, 7Z Brotli
+txt_7_4_7zfzstandardcomp: Fastest compression, 7Z Zstandard
+txt_7_4_presetrar: High compression, RAR
+txt_7_4_tkeep: Keep original archive timestamp
+txt_7_4_lock: Lock archive
+txt_7_4_locked: locked
+txt_7_4_lockconfirm: Locked archives cannot be further modified, proceed locking this archive?
+txt_7_4_recover: Repara l'arxiu
+txt_7_4_tcurr: Set archive timestamp from current system time
+txt_7_4_setarc: Set advanced archiving options
+txt_7_4_setext: Set advanced extraction options
+txt_7_4_swzipx: Switch to zipx extension for non-Deflate zip archives
+txt_7_3_archiveerrors: [archive may contain errors]
+txt_7_3_archiveerrorshint: Archive may not be valid (due missing, corrupted, or out of standard data), it is possible to run Test for detailed information. If archive's table of content is encrypted, password is needed before browsing it.
+txt_7_3_clickextall: Fes clic a "Extreu-ho tot" per habilitar-ho
+txt_7_3_noconfdel: Do not ask confirmation for delete after archiving / extraction
+txt_7_3_profile7zfastest: Fast compression, 7Z fastest
+txt_7_3_maxbr: Maximize Brotli compression using more memory (may be incompatible with some extractors)
+txt_7_3_maxzstd: Maximize Zstandard compression using more memory
+txt_7_3_profile7zfast: Medium compression, 7Z fast
+txt_7_3_stl: Set archive timestamp from most recent file
+txt_7_2_altcomp: High compression, ARC
+txt_7_2_clearnoupdate: Clear edited files
+txt_7_2_autoclosepeazip: Close PeaZip when task completes
+txt_7_2_zpaqall: Extract all revisions
+txt_7_2_extcomp: Extreme compression, ZPAQ
+txt_7_2_extcompultra: Extreme compression, ZPAQ ultra
+txt_7_2_fbrotlicomp: Fastest compression, Brotli
+txt_7_2_fzstandardcomp: Fastest compression, Zstandard
+txt_7_2_loadcompsettings: Load compression settings
+txt_7_2_savecompsettings: Save compression settings
+txt_7_2_source: Source
+txt_7_2_updateclear: Update edited files in archive, and clear edited files
+txt_7_1_type_description_brotli: Brotli: fast compressor from Google, very fast decompression
+txt_7_1_new: Extract all here (in new folder)
+txt_7_1_smart: Extract all here (smart new folder)
+txt_7_1_profileintermediate: Medium compression, ZIP/BZip2 fast
+txt_7_1_renfilesonly: Rename only files
+txt_7_1_typetosearch: Type to search in current path
+txt_7_1_type_description_zstd: Zstandard: fast compressor from Facebook, very fast decompression
+txt_7_0_af: Analyze content of folders
+txt_7_0_autoopentar: Auto open single tar archive inside tar.* files
+txt_7_0_exttmppath: Content will be extracted outside the temporary work path, in: 
+txt_6_9_autou: Auto update modified files in archives
+txt_6_9_forceu: Update edited files in archive
+txt_6_9_opuns: Operation not supported for current archive type
+txt_6_9_overarch: Overwrite file(s) with same name already existing inside the archive?
+txt_6_9_uconf: Previewed file has been modified. Update the current archive?
+txt_6_8_ndrop: Use native Drag and Drop on Windows
+txt_6_7_nop: (sense previsualització)
+txt_6_6_pdupfound: s'han trobat possibles duplicats (comprovació ràpida aproximada)
+txt_6_6_rsh: Neteja l'historial de cerques
+txt_6_6_pdupfind: Suggereix possibles duplicats
+txt_6_6_forcemodify: Edit non-canonical archive types
+txt_6_5_mandatory: (obligatori)
+txt_6_5_abort: Avorta
+txt_6_5_askp: Ask to set password at startup
+txt_6_5_chp: Canvia la contrasenya
+txt_6_5_def: Definició
+txt_6_5_nop: Don't ask to set password at startup
+txt_6_5_error: Error
+txt_6_5_seqerr: Error(s) detected, original files will not be deleted
+txt_6_5_sni: Include NT security information
+txt_6_5_sns: Include NTFS Alternate Data Stream
+txt_6_5_privacy: Privacitat
+txt_6_5_showvolatile: Show which options are volatile / context dependent
+txt_6_5_force: Try to open archives containing errors
+txt_6_5_warning: Avís
+txt_6_5_yes: Sí
+txt_6_5_yesall: Sí a tot
+txt_6_5_np: You can now change password of converted archive(s) to a new one, or blank the password to skip encryption
+txt_6_4_absolute: Camí absolut
+txt_6_4_appdirn: Append directory name
+txt_6_4_closeallother: Tanca totes les altres pestanyes
+txt_6_4_closeright: Tanca totes les pestanyes de la dreta
+txt_6_4_collapse: Comprimeix les pestanyes
+txt_6_4_expand: Expandeix les pestanyes
+txt_6_4_full: Camí complet
+txt_6_4_new: New
+txt_6_4_openintab: Obre en una pestanya nova
+txt_6_4_paths: Paths
+txt_6_4_prepdirn: Prepend directory name
+txt_6_4_relative: Camí relatiu
+txt_6_4_tabbar: Tab bar
+txt_6_3_autoadjust: Ajusta la columna automàticament
+txt_6_3_cinfo: Info and comments
+txt_6_3_syn: Synchronize archive with disk
+txt_6_3_uar: Update only files already in archive
+txt_6_2_encext: Add ".enc" suffix to encrypted archives
+txt_6_2_archive: Archive file type
+txt_6_2_container: Container file type
+txt_6_1_ec: Expand / collapse archive tree
+txt_6_0_msq: Sort by file type for solid compression
+txt_5_9_lff: Analyze files and folders
+txt_5_9_pff: Analyze, show files header/EOF
+txt_5_9_start: Start from
+txt_5_8_l0: Allow any supported component/format
+txt_5_8_l1: Allow only Free Software components
+txt_5_8_l2: Allow only open archive formats
+txt_5_8_ascii: ASCII safe, scripts are safe on legacy environments
+txt_5_8_cp: Code Page safe, scripts may trigger problems on legacy environments with different Code Pages
+txt_5_8_fs: Free Software compliance
+txt_5_8_utf: Scripts need full UTF-8 / Unicode environment
+txt_5_8_fsr: This format is not supported due Free Software compliance restrictions (Options > Advanced)
+txt_5_7_pinstalled: INSTAL·LAT
+txt_5_7_pmissing: MISSING
+txt_5_7_plugin: Plugin missing, can be installed from Help > Check for plugin and addon
+txt_5_6_basic: Basic
+txt_5_6_exarc: Extract archive
+txt_5_6_tab: Obre en una pestanya nova
+txt_5_6_rc: Right click for options
+txt_5_6_layouts: Saved layouts
+txt_5_6_upexisting: Update existing archive
+txt_5_6_verbose: Verbose
+txt_5_5_case: (sensible a les majúscules)
+txt_5_5_add: Add string at specified position
+txt_5_5_addsel: Afegeix a la selecció
+txt_5_5_ext: Canvia les extensions dels fitxers
+txt_5_5_plugin: Check for plugin and addon
+txt_5_5_copypath: Copy path
+txt_5_5_delete: Delete characters at specified position
+txt_5_5_halt: Halt system when task completes
+txt_5_5_positionw: Hint: 1 add before first char, 2 second, etc... "z" for end of file name
+txt_5_5_positionwd: Hint: 1 delete from first char included, 2 second, ... "z" for end of file name
+txt_5_5_replaceneww: Hint: provide an empty new string to simply remove the old string
+txt_5_5_lower: lowercase
+txt_5_5_replaceoldw: Modify all occurrences of this string or character in the file name
+txt_5_5_newext: Nova extensió
+txt_5_5_new: New string
+txt_5_5_n: Number of characters to delete
+txt_5_5_old: Old string
+txt_5_5_position: Position (number or "z" for end)
+txt_5_5_intdir: Nova carpeta intel·ligent
+txt_5_5_replacestr: Replace/remove string
+txt_5_5_datesameday: Same day of selected object
+txt_5_5_datesamehour: Same hour of selected object
+txt_5_5_datesamemonth: Same month of selected object
+txt_5_5_datesameweek: Same week of selected object
+txt_5_5_datesameyear: Same year of selected object
+txt_5_5_scan: Escaneja
+txt_5_5_select: Select
+txt_5_5_similar: Similar to selected object
+txt_5_5_starting: Starting with same character
+txt_5_5_string: String to add
+txt_5_5_subtractsel: Subtract from current selection
+txt_5_5_datehour: Aquesta hora
+txt_5_5_datemonth: Aquest mes
+txt_5_5_dateweek: Aquesta setmana
+txt_5_5_dateyear: Aquest any
+txt_5_5_dateday: Avui
+txt_5_5_upper: UPPERCASE
+txt_5_5_extw: Warning: changing file extension the file may become unusable
+txt_5_4_da: Date added
+txt_5_4_deletearchives: Delete archives after extraction
+txt_5_4_deletefiles: Delete files after archiving
+txt_5_4_deleteoriginal: Deletion procedure, as set in main screen, will be appended to the script.
+txt_5_4_lv: Last visited
+txt_5_4_deletearchivesconfirm: Confirm deletion of original archives?
+txt_5_4_deletefilesconfirm: Confirm deletion of original files?
+txt_5_4_used: Utilitzat
+txt_5_3_profilebest: Extreme compression, 7Z ultra
+txt_5_3_profileadvanced: High compression, 7Z
+txt_5_3_profilenormal: Medium compression, ZIP (compatible with most extractors)
+txt_5_3_profileveryfast: Fast compression, ZIP fast (compatible with most extractors)
+txt_5_3_profilepassword: Protect with password, 7Z format
+txt_5_3_profile10mb: Manté el resultat per sota dels 25 MB, per les limitacions d'enviament
+txt_5_3_profilesfx: Auto extracting, recipient will not need an extraction software
+txt_5_3_cml: Idioma del menú contextual del sistema
+txt_5_3_cmlmessage: Double click on desired context menu language and confirm registry merging. This setting needs to be re-applied when the application is installed/updated or after System integration wizard is used.
+txt_5_3_exc: Exclusion filters prevail on inclusion filters
+txt_5_3_ia: Inclou també
+txt_5_3_io: Inclou només
+txt_5_3_rec: Recurse subdirs
+txt_5_3_resetsi: Re-configure system integration (context menu, SendTo, file associations)?
+txt_5_2_oadd: Archive to original path
+txt_5_2_zerodelete: Vols eliminar i reemplaçar els fitxers seleccionats amb 0? La operació no es pot desfer i els fitxers no es podran recuperar
+txt_5_2_zfree: Vols reemplaçar l'espai lliure d'aquesta unitat amb 0?
+txt_5_2_sdfree: Vols esborrar l'espai lliure d'aquesta unitat de forma segura?
+txt_5_2_oext: Extreu a la ubitació original
+txt_5_2_securedeletefree: Elimina l'espai lliure de forma segura
+txt_5_2_free: Aquesta operació pot tardar uns minuts i, si es realitza sovint, pot desgastar ràpidament discs de memòria flash
+txt_5_2_zerofiles: Reemplaça amb 0
+txt_5_2_zerofree: Reemplaça l'espai lliure amb 0
+txt_5_1_schedadd: Afegeix una programació
+txt_5_1_schederr: No es pot crear la programació
+txt_5_1_daily: Diàriament
+txt_5_1_day: Dia
+txt_5_1_days: Dies
+txt_5_1_enddate: Data de finalització
+txt_5_1_every: Cada
+txt_5_1_w6: Divendres
+txt_5_1_hourly: Cada hora
+txt_5_1_hours: Hores
+txt_5_1_last: Last
+txt_5_1_schedmanage: Task Scheduler, manage tasks saved in PeaZip branch
+txt_5_1_scriptmanage: Manage saved scheduled scripts
+txt_5_1_w2: Dilluns
+txt_5_1_monthly: Mensualment
+txt_5_1_months: Mesos
+txt_5_1_onlogin: En iniciar la sessió de l'usuari
+txt_5_1_onstart: A l'engegada
+txt_5_1_once: Una vegada
+txt_5_1_w7: Dissabte
+txt_5_1_schedule: Schedule
+txt_5_1_schedexplain: Creates a plain text script from GUI task definition and schedule it. Scheduled tasks' scripts are saved in "Scheduled scripts" folder. To edit or delete scheduled tasks you can use system's Task Scheduler, all scheduled tasks created by PeaZip are collected in "PeaZip" branch of the tasks library.
+txt_5_1_schedok: Schedule created successfully
+txt_5_1_schedscripts: Saved scheduled scripts
+txt_5_1_startdate: Data d'inici
+txt_5_1_starttime: Hora d'inici
+txt_5_1_w1: Diumenge
+txt_5_1_schedname: Nom de la tasca, identifica tant el script desat com la tasca programada del sistema
+txt_5_1_ts: Programador de tasques
+txt_5_1_w5: Dijous
+txt_5_1_w3: Dimarts
+txt_5_1_w4: Dimecres
+txt_5_1_weekly: Setmanalment
+txt_5_1_weeks: Setmanes
+txt_5_0_bc: Breadcrumb
+txt_5_0_resetpm: Confirmes que vols reestablir l'administrador de contrasenyes? Totes les contrasenyes emmagatzemades a l'administrador de contrasenyes del PeaZip es perdran si ho confirmes.
+txt_5_0_enum: Enumera el contingut de la carpeta
+txt_5_0_music: Música
+txt_5_0_ps: Obre el PowerShell aquí
+txt_5_0_perf: Rendiment
+txt_5_0_pictures: Imatges
+txt_5_0_removeall: Elimina-ho tot
+txt_5_0_resetbookmarks: Reset Bookmarks to default? (Bookmarks can then be customized with Bookmarks > Organize)
+txt_5_0_sh: Historial de la sessió
+txt_5_0_skip: Skip enumerating directories' content in layout
+txt_5_0_videos: Vídeos
+txt_4_9_frame: Marc
+txt_4_9_listth: Llista i miniatures
+txt_4_9_shadow: Ombra
+txt_4_9_style: Estil
+txt_4_8_attach25: adjunt de 25 MB
+txt_4_8_crop: Retalla
+txt_4_8_detailsno: Detalls
+txt_4_8_details: Detalls i miniatures
+txt_4_8_fit: Ajusta a
+txt_4_8_fitl: Ajusta a la més gran
+txt_4_8_flip: Flip
+txt_4_8_fullscreen: Pantalla completa
+txt_4_8_fun: Funcions
+txt_4_8_h: Altura
+txt_4_8_keeparchive: Manté l'arxiu
+txt_4_8_noresize: Manté la mida original
+txt_4_8_iconl: Imatges grans
+txt_4_8_iconm: Icones i imatges
+txt_4_8_imagemanager: Administrador d'imatges
+txt_4_8_immersive: Immersiu
+txt_4_8_listno: Llista
+txt_4_8_aspect: Maintain aspect ratio
+txt_4_8_mirror: Simetria
+txt_4_8_presets: Presets
+txt_4_8_replace: Replace original image(s)? "No" apply the transformation in new file(s).
+txt_4_8_resize: Canvia la mida
+txt_4_8_rl: Gira a l'esquerra
+txt_4_8_rr: Gira a la dreta
+txt_4_8_stop: Atura
+txt_4_8_t: Transforma
+txt_4_8_w: Amplada
+txt_4_7_pk: Genera una contrasenya / fitxer-clau aleatori/a
+txt_4_7_spchar: Limita els caràcters a lletres i números
+txt_4_7_recycleask: Vols moure els fitxers seleccionats a la paperera de reciclatge?
+txt_4_7_recycle: Desplaça a la paperera de reciclatge
+txt_4_7_pcomp: Compressió potencial
+txt_4_6_am: Administrador d'arxius
+txt_4_6_fm: Administrador de fitxers
+txt_4_6_users: Usuaris
+txt_4_5_goupdate: Hi ha una actualització disponible. Vols obrir la web oficial del PeaZip per descarregar l'actualització?
+txt_4_5_b: Part inferior
+txt_4_5_koupdate: No s'han pogut comprovar les actualitzacions, no hi ha connexió amb el servidor d'actualitzacions
+txt_4_5_update: Comprova si hi ha actualitzacions
+txt_4_5_dock: Ancora
+txt_4_5_l: Esquerra
+txt_4_5_noupdate: El PeaZip està actualitzat
+txt_4_5_properties: Propietats
+txt_4_5_r: Dreta
+txt_4_5_pj: Saved scripts
+txt_4_5_shaddress: Mostra la barra d'adreça
+txt_4_5_shnav: Mostra la barra de navegació
+txt_4_5_shstatus: Mostra la barra d'estat
+txt_4_5_shtool: Mostra la barra d'eines
+txt_4_5_upxpj: Em sap greu, no es pot exportar la definició de la tasca, ja que aquesta acció o opció requereix executar múltiples comandes diferents
+txt_4_5_t: Part superior
+txt_4_4_confremoveall: Vols eliminar tots els fitxers personalitzats del PeaZip (Aplicacions, Preferits, Administrador de contrasenyes)?
+txt_4_4_confremove: Vols eliminar la configuració del PeaZip?
+txt_4_3_pwmanhint: Double click to edit items in password list, rightclick for options, Ctrl+C to copy passwords
+txt_4_3_exppl: Exporta la llista de contrasenyes
+txt_4_3_expple: Encrypted (backup Password Manager)
+txt_4_3_keeppw: Recorda la contrasenya/fitxer-clau durant la sessió actual
+txt_4_3_pwmanpwhint: Setting a password/keyfile (optional) to encrypt password list is recommended, in this way authentication will be required to access to the Password Manager. Password/keyfile can be changed at any time from this form.
+txt_4_3_pwmanmaster: Estableix/canvia la contrasenya global
+txt_4_3_pwmanlist: Llista de contrasenyes
+txt_4_3_pwman: Administrador de contrasenyes
+txt_4_3_pwmancorr: Password Manager seems tampered or corrupted. Keep Password Manager anyway and try to recover current password list, if you trust it? (No will reset Password Manager, recommended)
+txt_4_3_expplp: Text pla (tots els usuaris)
+txt_4_3_recsrc: Recursive search by default
+txt_4_3_resetpm: Vols reestablir l'administrador de contrasenyes? S'eliminaran totes les contrasenyes emmagatzemades
+txt_4_3_breadcrumb: Show Address as breadcrumb
+txt_4_2_arcabspath: Utilitza rutes absolutes
+txt_4_1_duplicateshint: "size"/"checksum" string is reported in CRC column for all duplicate candidates found in current directory or search filter
+txt_4_1_adminhint: (HINT: alternatively, you can request UAC elevation to work in protected paths, Alt+F10 or Options > Run as administrator)
+txt_4_1_selected: (selected)
+txt_4_1_duplicatesfound: duplicates found
+txt_4_1_duplicatesfind: Troba duplicats
+txt_4_1_runasadmin: Executa com a administrador
+txt_4_1_simplesearch: Cerca bàsica
+txt_4_0_thim: Show picture thumbnails
+txt_3_8_type_description_wim: WIM: Microsoft's disk image format
+txt_3_8_type_description_xz: XZ: powerful file compression based on LZMA2
+txt_3_7_donations: Donacions
+txt_3_7_nameasparent: Name archive as selected item's parent folder, if multiple items are added
+txt_3_7_tracker: Issue Tracker
+txt_3_7_sort: Ordena per
+txt_3_7_swapbars: Swap Tool bar / Address bar
+txt_3_7_themedbars: Themed bars
+txt_3_6_ignoredd: Always ignore paths for Drag and Drop extraction
+txt_3_6_close: Tanca
+txt_3_6_resetapps: Do you want to reset Applications (customizable group of programs and scripts to open files with, overriding file associations)?
+txt_3_6_ethemes: Temes existents
+txt_3_5_td: Descarrega temes
+txt_3_5_managecustomthemes: Administrador de temes
+txt_3_4_nopaths: Sense rutes
+txt_3_4_smallicons: Icones
+txt_3_3_skipunits: (Windows) Recopila informació dels volums d'unitats en xarxa, inici més lent
+txt_3_3_stralt: Comanda alternativa, quan no s'especifiqui cap paràmetre
+txt_3_3_apps: Aplicacions
+txt_3_3_multi: Selecció múltiple
+txt_3_3_runexp: Obre un programa, fitxers, carpeta o lloc web
+txt_3_3_apppath: Carpeta del PeaZip
+txt_3_3_run: Executa
+txt_3_2_7zutf8nonascii: 7z / p7zip -mcu use UTF8 for file names containing non-ASCII symbols inside .zip files
+txt_3_2_alltasks: Totes els tasques
+txt_3_2_conf: Configuració
+txt_3_2_donations: Donate to charitable organizations
+txt_3_1_sccenc: 7z/p7zip CONSOLE character encoding
+txt_3_1_downloads: Descàrregues
+txt_3_1_lib: Biblioteques
+txt_3_1_more: Més
+txt_3_1_openasarchive: Obre com a arxiu
+txt_3_1_sendto: User’s SendTo menu folder
+txt_3_1_pathexc: La ruta excedeit la mida màxima permesa
+txt_3_1_recent: Recents
+txt_3_1_plsmartmin: Executa minimitzat, mostra'l/manten-lo obert només quan sigui necessari
+txt_3_1_src: Cerques
+txt_3_1_systmp: Carpeta temporal de l'usuari
+txt_3_1_languagetools: Tradueix
+txt_3_1_workingdir: Directori de treball
+txt_3_0_nonreadableorpw: Archive is not readable. The archive may not be valid, volumes may be missing, or its table of content could be encrypted. Would you like to try a password?
+txt_3_0_readablepw: L'arxiu pot estar protegit amb contrasenya
+txt_3_0_configure: Associació de fitxers i integració del menú del sistema
+txt_3_0_resettmp: Reset peazip-tmp
+txt_2_9_address: Barra d'adreces
+txt_2_9_adv: Advanced filters are applied when managing any file supported through 7z or FreeArc backends, see documentation, and overrides basic filters (that are used for search functions and are displayed in Bookmarks and History panels)
+txt_2_9_columns: Columnes
+txt_2_9_copyhere: Copia aquí
+txt_2_9_noscan: Don't scan files being added to layout
+txt_2_9_extconsole: Extraction console is available only while browsing archives
+txt_2_9_thl: Highlight buttons
+txt_2_9_home: Home
+txt_2_9_lt: Gran
+txt_2_9_mt: Mitjà
+txt_2_9_movehere: Mou-lo aquí
+txt_2_9_nav: Navegació
+txt_2_9_navbar: Barra de navegació
+txt_2_9_none: Cap
+txt_2_9_organize: Organitza
+txt_2_9_public: Públic
+txt_2_9_rec: Recursive: search in subdirectories, may take some time
+txt_2_9_selected: Seleccionat
+txt_2_9_setapps: Organitza les aplicacions
+txt_2_9_showmenu: Mostra la barra de menús
+txt_2_9_st: Petit
+txt_2_9_test_pw2G: Test for encryption <2GB archives
+txt_2_9_vst: Només text
+txt_2_9_toolbar: Barra d'eines
+txt_2_9_tree: Arbre
+txt_2_9_views: Vistes
+txt_2_8_experimental: (experimental)
+txt_2_8_zcopy: (Windows) Copy files in restartable mode, slower copy
+txt_2_8_addvol: Adding entire volume(s) to archive may take long time, continue anyway?
+txt_2_8_uniterror: No es pot accedir a la unitat
+txt_2_8_cannotconvert: Cannot convert selected archives
+txt_2_8_convertbegin: Continue with compression stage to finalize the conversion?
+txt_2_8_convert: Converteix
+txt_2_8_convertexisting: Converteix els fitxers existents
+txt_2_8_convertdelete: Delete files and folders created temporarily for conversion?
+txt_2_8_details: Detalls
+txt_2_8_parallel: Executa les tasques en paral·lel quan sigui possible
+txt_2_8_convertnote: In any case original archives were not modified, to let the user in control about keeping or removing them
+txt_2_8_custom: is not directly supported by PeaZip, but in extraction stage you can set PeaZip to handle custom file types in "Advanced" tab. Proceed opening this file?
+txt_2_8_unitrecommend: It is recommended either to extract (rightclick > extract selected) or to open filesystems from computer's root (system tools > Open unit as archive)
+txt_2_8_viewasarchive: Open unit as archive
+txt_2_8_nounit: No s'ha seleccionat cap unitat
+txt_2_8_rowselect: Row select
+txt_2_8_statusbar: Barra d'estat
+txt_2_8_typeunit: Type logical or physical unit name
+txt_2_8_usedefaultoutpath: Utilitza sempre la ubicació d'extracció per defecte
+txt_2_7_experimental: (experimental, vegeu la documentation)
+txt_2_7_optional: (opcional)
+txt_2_7_list_tryflatorpw: , possible solutions: try flat view (F6), provide password (F9), get a fresh copy of the archive
+txt_2_7_separate: Add each object to a separate archive
+txt_2_7_pwsupported: archiving with password
+txt_2_7_cancel: Cancel·la
+txt_2_7_encfn: Encripta també els noms dels fitxers (si el format ho suporta)
+txt_2_7_setpw: Introdueix una contrasenya / fitxer-clau
+txt_2_7_ext: Extraient:
+txt_2_7_extfrom: Extraient de l'arxiu:
+txt_2_7_es: Extract supported non-archive file types, i.e. executables, MS Office and OOo files
+txt_2_7_eu: Extract unsupported file types, specifying custom extraction utility
+txt_2_7_clipboard: Porta-retalls
+txt_2_7_goarclayout: Go to archiving layout
+txt_2_7_goextlayout: Go to extraction layout
+txt_2_7_ok: OK
+txt_2_7_drag_archive: open file as new archive? ("No" to add file to current archiving layout)
+txt_2_7_oop: Obra la ubicació d'extracció quan finalitzi el procés
+txt_2_7_validatefn: Operation stopped, invalid file name detected:
+txt_2_7_validatecl: Operation stopped, potentially dangerous command detected (i.e. command concatenation not allowed within the program):
+txt_2_7_output: Output
+txt_2_7_pwnotset: Password is not set 
+txt_2_7_pwarcset: Password is set
+txt_2_7_pwextset: Password is set, it is possible to extract/list/test encrypted archives
+txt_2_7_archivehint: Drag here files and folders to archive, or right-click for more options
+txt_2_7_exthint: Drag here archives to extract, or right-click for more options
+txt_2_7_setadvf: Set advanced filters
+txt_2_7_selpath: Selected item's path
+txt_2_7_separateerror: Sorry, cannot import task definition's command line while using "Add each object to a separate archive" switch, since the task is performed as multiple distinct commands
+txt_2_7_noinput: The layout is empty: please use Add file(s) or Load Layout to populate the list of archives to be extracted
+txt_2_7_dirsize: The size of the content of folders is not checked for calculating the total size
+txt_2_7_un7z_browse_flat: try flat view (F6)
+txt_2_7_updating: Updating existing archive
+txt_2_6_folders: (carpetes)
+txt_2_6_advanced: Avançat
+txt_2_6_plalways: Always keep open to inspect task's report
+txt_2_6_plsmart: Keep open only if needed (error, list or test reports)
+txt_2_5_sessionio: (aquesta sessió)
+txt_2_5_advanced: Advanced edit: place spaces between parameter strings and filename if needed
+txt_2_5_basic: Basic edit: application and parameters before input name
+txt_2_5_cannotrun: Cannot run
+txt_2_5_custeditors: Custom editors, players, antivirus scanners etc... (override system's file associations)
+txt_2_5_delete: Delete
+txt_2_5_delete_fromarchive: Delete from archive
+txt_2_5_langflag: Display archived object's name as UTF-8 text; uncheck to replace extended characters with "?"
+txt_2_5_encpj: Encode task definition as UTF-8 text
+txt_2_5_execommand: Executable or command
+txt_2_5_help: Ajuda
+txt_2_5_langhint: Hint: replacing extended characters with "?" jolly character can improve syntax if archive's character set cannot be successfully converted on the current machine
+txt_2_5_mini_help: Localized Tutorial
+txt_2_5_offline_help: Ajuda del PeaZip
+txt_2_5_tray: Reduce to tray
+txt_2_5_remove: Remove
+txt_2_5_hintpaths: Rightclick to open system's and user's paths
+txt_2_5_selectapp: Select application
+txt_2_5_strafter: String after input name
+txt_2_5_strbefore: String before input name
+txt_2_5_encoding: Codificació del text
+txt_2_5_nopw: this type of archives does not support encryption
+txt_2_4_draghint: [drag to Explorer with enabled Address bar]
+txt_2_4_tb: Adapt toolbar buttons (restarts PeaZip)
+txt_2_4_adding: Afegint
+txt_2_4_advclip: Clipboard keeps multiple selections
+txt_2_4_yanswers: Answers
+txt_2_4_itemsheight: Auto-size items height
+txt_2_4_clearclipboard: Clear clipboard (Esc)
+txt_2_4_wcommons: Commons
+txt_2_4_copyfrom: Copia desde
+txt_2_4_deletebookmarks: Do you want to delete the list of bookmarked files and folders?
+txt_2_4_documents: Documents
+txt_2_4_wenc: Encyclopedia
+txt_2_4_extractfrom: Extreu desde
+txt_2_4_hexp: Previsualització hex
+txt_2_4_operation: Operació
+txt_2_4_path: la ubicació no es pot escriure (p.ex. només lectura). Vols seleccionar una altra ubicació d'extracció escrivible?
+txt_2_4_removefromclipboard: Elimina del porta-retalls
+txt_2_4_stdclip: Standard: keep a single selection in clipboard, clear cut operations on paste
+txt_2_4_totalmem: memòria total
+txt_2_4_gvideo: Vídeo
+txt_2_4_wbook: Wikibook
+txt_2_4_wnews: Wikinews
+txt_2_4_wsrc: Wikisource
+txt_2_4_wdict: Wiktionary
+txt_2_3_pw_errorchar: quote character is not recommended to be used in passwords (for PeaZip and scripts). If you need to create or extract an archive with this password you can dismiss the message and you will be asked to enter the password interactively in console.
+txt_2_3_envstr: Display environment variables
+txt_2_3_never_pw: Don't ask for password
+txt_2_3_home: User's home
+txt_2_3_on_pw: On extract/list/test operations from system's menus:
+txt_2_3_test_pw100: Test for encryption <100MB archives
+txt_2_3_test_pw: Test for encryption (may be slow)
+txt_exclude_recourse: "exclude" recurse subdirs
+txt_action_extopen: "Extract and open with associated application" action
+txt_error_passwordnotmatch: "Password" and "Confirm" fields doesn't match, please correct them
+txt_action_preview: "Preview with associated application" action
+txt_preview_hint: "Preview" action perform the same task as "Extract and open" but to a temporary path in output directory, automatically removed when the archive is closed.
+txt_better: (millor)
+txt_default2: (per defecte)
+txt_faster: (més ràpid)
+txt_fastermem: (més ràpid, menys memòria)
+txt_tempdir: (PeaZip's temporary work folder)
+txt_stream: (set by "Stream control")
+txt_slowermem: (més lent, més memòria)
+txt_store: (store, fastest)
+txt_newfolder: (en una carpeta nova)
+txt_7z_exitcodeunknown: : Error de tasca desconegut
+txt_list_isfolder:  [carpeta]
+txt_none: <none>
+txt_fd: 1.44 MB Disquet
+txt_7z_exitcode1: 1: Warning: non fatal error(s); i.e. some files missing or locked
+txt_attach10: adjunt de 10 MB
+txt_7z_exitcode2: 2: Fatal error occurred
+txt_7z_exitcode255: 255: Task halted by the user
+txt_fat32: 4 GB Fitxer FAT32
+txt_dvd: 4.7 GB DVD
+txt_attach5: adjunt de 5 MB
+txt_cd650: 650 MB CD
+txt_7z_exitcode7: 7: Error: got incorrect command line
+txt_cd700: 700 MB CD
+txt_type_description_7z: 7Z: feature rich archive format with high compression ratio
+txt_dvddl: 8.5 GB DVD DL
+txt_7z_exitcode8: 8: Error: not enough memory for requested operation
+txt_abort: Abort scheduled file copy/move operations?
+txt_about: About
+txt_action: Acció
+txt_action_hint: Action on open or preview with associated application
+txt_add: Afegeix
+txt_add_existing_archive: Add (if archive exists)
+txt_add_archive: Add archive
+txt_add_files: Add file(s)
+txt_add_folder: Add folder
+txt_add_path: Add path
+txt_add_tolayout: Add selected files and folders to archive's layout
+txt_add_toarchive: Add to archive
+txt_add_tobookmarks: Add to bookmarks
+txt_address_hint: Filter: accepts * and ? wildcards
+txt_adv_filters: Filtres avançats
+txt_algo: Algoritme
+txt_all: tot
+txt_all_default: Tot (per defecte)
+txt_all_type: Mateix tipus
+txt_all_date: Data
+txt_all_psize: Mida del fitxer empaquetat
+txt_all_attributes: Mateixos atributs
+txt_all_size: Mida del fitxer
+txt_error_input_upx: allows a single executable file as input
+txt_always_pw: Pregunta'm sempre una contrasenya
+txt_ignore_ext: Ignora sempre els camins per "Extreu i..."
+txt_ignore_disp: Ignora sempre els camins per "Extreu els visibles..."
+txt_ignore_sel: Ignora sempre els camins per "Extreu els seleccionats..."
+txt_key_hint: Append keyfile's hash to password; the archive can be decrypted by PeaZip and other applications following the same standard, or entering the hash as part of the password
+txt_timestamp: Append timestamp to name
+txt_appoptions: Opcions de l'aplicació
+txt_type_description_arc: ARC: arxivador experimental, potent, eficient i amb moltes característiques
+txt_archive: Arxiu
+txt_un7z_browse_ok: archive browsed successfully
+txt_interface: Archive browser interface
+txt_archivecreation: Archive creation
+txt_tarbefore_hint: Archive data in TAR format before than in specified type.
+txt_archive_hint: Archive, compress, split and keep private files, folders and volumes
+txt_compressionratio_hint: Archive's compression ratio
+txt_archiving: Arxivant:
+txt_cl_long: Arguments seem exceeding the maximum size that can be passed by PeaZip frontend, please select less input files (i.e. select dirs instead of single files)
+txt_overwrite_askbefore: Pregunta'm abans de substituir fitxers (a la consola)
+txt_associated: Aplicació associada
+txt_attributes: Atributs
+txt_author: Autor
+txt_ren_existing: Reanomena automàticament els fitxers existents
+txt_ren_extracted: Reanomena automàticament els fitxers extrets
+txt_autofolder: Automatically create new folder to extract the archive in?
+txt_back: Endarrera
+txt_backend: Backend binaries user interface
+txt_backupexe: Backup executable (recommended)
+txt_bettercompression: millor compressió
+txt_blogs: Blogs
+txt_blowfish: Blowfish448 (blocs de 64 bit)
+txt_bookmarks: Bookmarks
+txt_browse: Navega
+txt_browser: Navegador
+txt_aborted_error: Browsing archive stopped, it would take too much time. You can narrow the selection using search (F3) or avoiding Flat view mode (F6). You can directly extract, list or test the archive.
+txt_list_browsing: Browsing
+txt_archive_root: Browsing: archive's root
+txt_type_description_bzip2: BZip2: quite powerful compression, average speed
+txt_pw_empty: Please provide a password (or a keyfile)
+txt_add_error: Cannot add/update or delete object(s). The archive is not writeable, or cannot support this operation. Editing non-canonical archive types can be enabled in Archive manager options.
+txt_un7z_browse_failure: cannot browse archive
+txt_list_error: Cannot list archive's content, please check if the archive is password protected or corrupted.
+txt_conf_cannotsave: Cannot save configuration file, check if the path is writeable and with some free space
+txt_check_hint: Check for casual data corruption; hash algorithms are suitable to detect even malicious data tampering (see the documentation)
+txt_check: Checksum/hash file(s)
+txt_check_select: Checksum/hash
+txt_clear: Neteja
+txt_clearlayout: Clear layout
+txt_pj_hint: Click to import task, reset changes and load up to date task definition from GUI
+txt_autoclose: Close PeaLauncher when task completes
+txt_cl: línia de comandes:
+txt_compare: Compara els fitxers
+txt_compress: Comprimeix
+txt_compress_executable: Compress executable
+txt_compress_openforwriting: Compress files open for writing
+txt_compression: Compressió
+txt_compmanagement: Computer management
+txt_pw_confirm: Confirma
+txt_console: Consola
+txt_console_interface: Console: native interface
+txt_content: Contingut
+txt_controlpanel: Control panel
+txt_convert: Convert disk to NTFS
+txt_copy: Copia
+txt_copyto: Copia a...
+txt_create: Create
+txt_create_archive: Create new archive
+txt_title_create: Create archive, compress, encrypt, split...
+txt_create_keyfile: Crea un fitxer-clau
+txt_create_folder: Create new folder
+txt_create_theme: Create Theme from current settings
+txt_rr: Create recovery records
+txt_create_sfx: Create self-extracting archive
+txt_cr_current: Current path or filter compression ratio
+txt_custom: Custom
+txt_type_description_custom: Custom (advanced users): enter executable name and parameters
+txt_customapp: Aplicació personalitzada
+txt_custom_parameters: Paràmetres personalitzats
+txt_customsize: Mida personalitzada
+txt_cut: Retalla
+txt_datetime: Data/hora
+txt_default: per defecte
+txt_default_compression: compressió per defecte
+txt_default_format: Format per defecte
+txt_theme_default: Tema per defecte
+txt_hard_reset_hint: Delete bookmarks file
+txt_desktop: Escriptori
+txt_dictionary: Diccionari
+txt_dirs: dir(s),
+txt_dis: Disambiguation:
+txt_disk_cleanup: Disk cleanup
+txt_disk_defrag: Disk defrag
+txt_disk_management: Disk management
+txt_dispaly: Display results as
+txt_displayedmnu_obj: displayed
+txt_displayedobjects: Displayed objects
+txt_nocompress: no comprimeixis
+txt_delete: Do you want to delete selected file(s)? The operation can't be undone and files will be not recoverable from recycle bin
+txt_wipe: Do you want to securely delete selected file(s)? The operation can't be undone and files will be not recoverable
+txt_done: Fet
+txt_edit: Edita
+txt_elapsed: elapsed:
+txt_error_emptycl: Empty command line!
+txt_encrypt: Encripta
+txt_encrypted: encriptat
+txt_encryption: Encriptació
+txt_note: Enter note / description
+txt_random_keys: Enter random keys
+txt_random_keys_hint: Enter random keys (you not have to remember)
+txt_ent: Entropy evaluation
+txt_ent_tools: Move the mouse or use additional entropy sampling tools
+txt_eqorlarger: Igual o més gran que el fitxer seleccionat
+txt_eqorrecent: Igual o més recent que el fitxer seleccionat
+txt_eqorolder: Igual o més antic que el fitxer seleccionat
+txt_eqorsmaller: Igual o més petit que el fitxer seleccionat
+txt_equal: Igual que el fitxer seleccionat
+txt_erase_hint: Secure delete: overwrite with random data, mask size, rename, finally delete
+txt_extraction_error: Error extracting the selected object. If the archive is password protected please provide it
+txt_exclude_hint: Exclude file(s), one per line; use * and ? wildcards; " and ' delimiters are not needed
+txt_exclusion_recourse: Exclusion filters recurse subdirs
+txt_exclusion: Exclou
+txt_exe: Executable
+txt_overwrite_qry: exists in destination path; overwrite with file(s) with same name from source path? (Cancel: skip copying this object)
+txt_confirm_overwrite: exists; overwrite it? (no to skip)
+txt_explore_outpath: Explora la ubicació d'extracció
+txt_explore_path: Explora la ubicació
+txt_ext: Ext:
+txt_caption_extract: Extreu
+txt_ext_nopath: Extreu (sense camí)
+txt_ext_all: Extreu-ho tot
+txt_ext_allhere: Extreu-ho tot aquí
+txt_ext_allto: Extreu-ho tot a
+txt_extopen_custom: Extract and open with custom application
+txt_extopen_with: Extract and open with...
+txt_ext_disp_here: Extract displayed here
+txt_ext_disp: Extract displayed object(s)
+txt_ext_disp_to: Extract displayed object(s) to...
+txt_ext_here: Extreu-ho aquí
+txt_ext_sel_here: Extreu la selecció aquí
+txt_ext_sel: Extreu els objectes seleccionats
+txt_ext_sel_to: Extreu els objectes seleccionats a...
+txt_extobj: Extreu l'objecte
+txt_newfoldermenu: Extreu-ho en una carpeta
+txt_extto: Extreu-ho en un altre lloc...
+txt_level_fast: Ràpid
+txt_fastcompr: compressió ràpida
+txt_fastopen: Fast open routine, stop browsing extremely large archives, use filters instead
+txt_level_fastest: Més ràpid
+txt_favformats: Favorite formats shortcuts
+txt_file: Fitxer
+txt_filebrowser: File browser / archive browser
+txt_filetools: File tools
+txt_files: fitxer(s),
+txt_nfiles: Fitxers
+txt_fs: Sistema de fitxers
+txt_filters_recourse: filter(s) recurse subdirs
+txt_filters: Filtres
+txt_flat: Pla (mostra-ho tot)
+txt_list_flat: Vista plana
+txt_unit_floppy: Floppy disk
+txt_foldername: Nom de la carpeta
+txt_nfolders: Carpetes
+txt_error_input_multi: format allows a single file as input; you can use "TAR before" switch to save input in a .TAR archive before, otherwise you can chose another format. HINT: chose archive format after had selected input data: "TAR before" switch will be automatically set
+txt_fwd: Endavant
+txt_list_found: Trobat
+txt_free: Lliure
+txt_free2: lliure
+txt_name_full: Nom complet
+txt_function: Funció
+txt_general: General
+txt_multithreading: Generic multithreading
+txt_go_browser: Go to file browser
+txt_go_path: Explore path (PeaZip)
+txt_guicl: Graphic + console
+txt_guipealauncher: Graphic: wrapped by PeaLauncher
+txt_graphic: Graphic's folder
+txt_gridaltcolor: Grids alternate color
+txt_gridrowheight: Grids row height
+txt_gui: GUI
+txt_type_description_gzip: GZip: compressió més ràpida
+txt_here: aquí
+txt_list_history: Historial
+txt_homeroot: Computer/archive's root level
+txt_quickbrowse_hint: If browsing is stopped the user can narrow the selection using search or filter functions; extract/list/test functions are not affected in any way.
+txt_backupexe_hint: If something goes wrong and lead to a non functional result, you may recover the original executable from the automatic backup copy
+txt_attach: If the mail client supports that command, the archive will be attached to a new mail
+txt_images: Images
+txt_include_hint: Include file(s), one per line; use * and ? wildcards; " and ' delimiters are not needed
+txt_filters_hint: Inclusion and exclusion filters for 7z binary, please carefully read 7-Zip documentation to understand how those filters works
+txt_inclusion_recourse: Inclusion filters recurse subdirs
+txt_inclusion: Include
+txt_error_function: Incorrect function requested
+txt_info: Info
+txt_infoall: Info on all
+txt_infodisp: Info on displayed object(s)
+txt_infosel: Info on selected object(s)
+txt_inputinfo: Input information
+txt_input_list: Input list:
+txt_iop: input, output, parameters
+txt_ipo: input, parameters, output
+txt_input: input:
+txt_integrity: Integrity check
+txt_chunk_size: Invalid custom size, please correct it in a numerical value
+txt_invertsel: Invert selection
+txt_type_exe: is a Windows executable, do you want to run it? ("No" to try open it as archive) HINT: some executables may not properly run unless the whole archive is extracted before
+txt_return_to_archive: is currently open; do you want to browse it?
+txt_not_accessible: is no longer accessible
+txt_type_unsupported: is not a supported archive type
+txt_checkname_failed: is not a valid name.
+txt_not_accessible_list: is not accessible, please check if the file list provided is correct and up to date
+txt_theme_create_error: It was not possible to create the theme, try to use a name valid for a folder as theme name and to chose a writeable path
+txt_theme_exists: yet exists, please provide a different path
+txt_job_code: task code:
+txt_job_definition_saved: Task definition successfully saved in
+txt_job_success: Task successfully completed!
+txt_join: Join
+txt_joinfiles: Join files
+txt_keyfile: Fitxer-clau
+txt_keyfile_not_found: Keyfile cannot be found or read. Please chose a different Keyfile.
+txt_keyfile_notcreated: KeyFile not created
+txt_larger: Larger than selected object
+txt_lastused: Last used
+txt_launch: Launch task
+txt_layout: Layout
+txt_filelist_savedas: Layout saved as
+txt_level: Nivell
+txt_license: Llicència
+txt_caption_list: Llista
+txt_list_details: Llista (amb detalls)
+txt_list_all: Llista-ho tot
+txt_list_disp: Llista els objectes visibles
+txt_list_sel: Llista els objectes seleccionats
+txt_toggle_warning: Listing flat view of path's content may take long time, continue anyway?
+txt_loadfile: Load file
+txt_loadlayout: Load layout
+txt_unit_hd: Disc local
+txt_localization: Idioma
+txt_lpaqver: LPAQ version
+txt_type_description_lpaq: LPAQ: faster version of PAQ, very good compression
+txt_maininterface: Main interface
+txt_maxcomp: Modalitat de compressió màxima
+txt_level_maximum: Màxim
+txt_restartrequired: May require restarting the application to be applied
+txt_required_memory: MB of memory required
+txt_method: Mètode
+txt_misc: Misc
+txt_modify: Modifica
+txt_morecontrols: More controls (history, bookmarks, ...)
+txt_morerecent: More recent than selected object
+txt_ent_hint: Move the mouse, enter keys in the edit field, load files to collect entropy from the system...
+txt_moveto: Desplaça a...
+txt_mypc: Directori arrel del sistema
+txt_list_na: n/a
+txt_name: Nom
+txt_naming: Política de noms
+txt_unit_remote: Network drive
+txt_newarchive: Nou arxiu
+txt_cnewfolder: Nova carpeta
+txt_news: Notícies
+txt_no: No
+txt_noinput: No accessible input received
+txt_nocompress_hint: no compression (faster)
+txt_split_noinput: No input selected; please select a file to split
+txt_open_noinput: No input selected; please select an archive (first archive's volume for multi-volume archives)
+txt_list_nomatch: no match
+txt_singlethread: No multithreading
+txt_none2: none
+txt_nonsolid: Non-solid
+txt_level_normal: Normal
+txt_copy_error: not successfully copied or moved, error code:
+txt_description: Notes
+txt_compare_second: Now select file to be compared with
+txt_peaobj: Object control
+txt_displayed_obj: object(s)
+txt_olderthan: Older than selected object
+txt_on: on
+txt_ondblclick: En fer doble clic
+txt_opacity: Opacitat
+txt_open: Obre
+txt_openarchive: Obre un document
+txt_title_open: Obre un document, desencripta'l, uneix-lo...
+txt_open_bookmark: Open bookmark
+txt_cphere: Executa una ordre aquí
+txt_open_file: Obre un arxiu
+txt_open_files: Obre arxius
+txt_open_path: Obre una ubicació
+txt_opensource: Open source portable archiver
+txt_openwith: Obre amb...
+txt_aborted: Operació avortada
+txt_unit_cd: Unitat òptica
+txt_options: Opcions
+txt_other: Other
+txt_otherparams: Other parameters (free editing)
+txt_oip: output, input, parameters
+txt_opi: output, parameters, input
+txt_output: output:
+txt_overwrite: Substitueix els fitxers existents
+txt_compressed_size: Empaquetat
+txt_paqver: PAQ version
+txt_type_description_paq: PAQ: slow but extremely powerful compressor
+txt_pio: parameters, input, output
+txt_poi: parameters, output, input
+txt_parameters: Paràmetres:
+txt_error_partial: Partial extraction not implemented for current archive type
+txt_passes: Passes
+txt_pw: Contrasenya
+txt_pwlength: Longitud de la contrasenya en caràcters (4..64)
+txt_un7z_browse_pw: potser es requereix una contrasenya
+txt_un7z_browse_pw_other: potser la contrasenya és incorrecta
+txt_paste: Enganxa
+txt_path: Camí
+txt_pea_appcolor: Application accent
+txt_pea_textcolor: Pea text color
+txt_type_description_pea: PEA: security oriented archive format with fast compression
+txt_peazip_new: PeaZip (instància nova)
+txt_peazip_help: Suport en línia
+txt_peazip_web: Lloc web del PeaZip
+txt_performall: Tots els algoritmes
+txt_name_provide: Els caràcters \ / : * ? ' " < > | no es permeten als noms dels fitxers
+txt_upxorstrip: Please chose Strip and/or UPX on the binary
+txt_not_removable_file: Please close file in use, in order to allow PeaZip to remove it:
+txt_not_removable: Please close files in use, in order to allow PeaZip to remove the folder:
+txt_custom_executable_missing: Please provide the custom executable's name
+txt_type_unsupported_select: Si us plau, selecciona un tipus de fitxer suportat:
+txt_no_theme_name: Si us plau, especifica el nom del tema
+txt_please_wait: Si us plau, espera un moment...
+txt_copy_wait: Please wait currently scheduled file copy/move operations to complete before scheduling other operations of the same type
+txt_previewwith: Previsualitza amb...
+txt_projectadmin: Project administrator:
+txt_type_description_quad: BALZ/QUAD: high-performance ROLZ-based file compressors
+txt_quickdelete: Eliminació ràpida
+txt_quit: Surt
+txt_unit_ram: RAM disk
+txt_read: Read:
+txt_recentarchives: Arxius recents
+txt_rr_hint: Recovery records allows to try to correct archives in case of data corruption
+txt_search_refine: Refine search filter, accepts ? and * wildcards
+txt_fefreshf5: Actualitza (F5)
+txt_release: release:
+txt_unit_removable: Unitat extraïble
+txt_remove_bookmark: Remove bookmark
+txt_remove_external_unit: Remove external device(s)
+txt_removeselected: Remove selected object(s)
+txt_rename: Reanomena
+txt_caption_repair: Repara
+txt_restartrequired2: requereix reiniciar l'aplicació per aplicar els canvis
+txt_reset: Reestableix
+txt_reset_archivename: Reestableix el nom del fitxer
+txt_hardreset: Reset bookmarks
+txt_reset_theme: Reset to embedded theme
+txt_restore_att: restore original attributes
+txt_run_as: Executa-ho com a (no es pot utilitzar un usuari amb la contrasenya en blanc)
+txt_run_as2: Executa-ho com un usuari diferent
+txt_sample: Sample: 
+txt_saveas: Anomena i desa
+txt_savehistory: Desa l'historial
+txt_save_infolder: Save in folder (auto)
+txt_savejob: Save task definition
+txt_savejobdefinition: Save task definition
+txt_savejobdefinition_hint: Save task definition as plain text; you can use it from your scripts
+txt_savelayout: Save layout
+txt_save_winstate: Save main window state
+txt_search: Search (recursive, may take some time)
+txt_searchanddrag: Search and drag here
+txt_searchfor: Search
+txt_nrsearch: Cerca aquí (no recursiu)
+txt_search_hint: Search in archive's subdirectories for matches with filter(s)
+txt_search_web: Cerca en línia
+txt_list_searching: Cercant...
+txt_securedelete: Eliminació segura
+txt_default_description: Select a function or drag files here
+txt_selectall: Selecciona-ho tot
+txt_selectdir: Selecciona un directori
+txt_selected_obj: selected
+txt_selected_objects: Selected objects
+txt_sfx: Self-extracting
+txt_sendbymail: Envia per e-mail
+txt_set_defaults: Set application's default parameters
+txt_settings: Configuració
+txt_sfx_interface: sfx interface
+txt_showhints: Show hints
+txt_show_messages: Mostra els missatges informatius
+txt_showpw: Mostra el contigut del camp de la contrasenya
+txt_singlevol: Single volume, do not split
+txt_size: Mida
+txt_sizeb: Mida (B)
+txt_skip_existing: Omet els fitxers existents
+txt_slowercomp: compressió més lenta però descompressió igual de ràpida
+txt_smaller: Smaller than selected object
+txt_solid: Solid
+txt_solid_block: Mida del bloc
+txt_solid_auto: Solid, auto-adjust
+txt_solid_extension: Solid, group by extension
+txt_listtest: sorry, list/test operation is not yet implemented for this format
+txt_sortbysel: Sort by selection status
+txt_list_sorting: Ordenant...
+txt_speed: velocitat
+txt_split: Divisió
+txt_type_description_split: Split a file with optional integrity check
+txt_split_file: Divideix el fitxer
+txt_list_nostats: no hi ha estadístiques disponibles
+txt_status: Estat
+txt_level_store: Store
+txt_stream_control: Stream control
+txt_strip: Strip before UPX (recommended)
+txt_keyfile_created: Successfully created KeyFile as:
+txt_suggestpw: Create random password
+txt_noupx: Symbols stripped, UPX compression omitted
+txt_syntax: Syntax:
+txt_sysbenchmark: System benchmark
+txt_benchmark: System benchmark will take some minutes and will use all available CPU and memory resource. The system may not respond during the benchmark; run it anyway?
+txt_systools: System tools
+txt_tarbefore: TAR before
+txt_type_description_tar: TAR: archiving format mainstream on UNIX systems
+txt_taskman: Task Manager
+txt_caption_test: Verifica
+txt_testall: Verifica-ho tot
+txt_testdisp: Verifica els objectes mostrats
+txt_testpw: Verifica la contrasenya / fitxer-clau
+txt_testsel: Verifica els objectes seleccionats
+txt_col_hint: The color should be chosen in order to integrate well with icon colors and to other GUI's elements
+txt_bookmarks_hint: The complete and editable list of bookmarks is available in the file browser interface, clicking on the "More controls" icon and on "Toggle history/bookmarks"
+txt_archive_noinput_tolist: The layout is empty: please use Add file(s), Add folder(s) or Load Layout to populate the archive's layout
+txt_theme: Tema
+txt_icons_found: Tema carregat satisfactòriament.
+txt_themename: Nom del tema
+txt_icons_not_found: Theme not loaded correctly. Try to switch to the default theme, or to a known working one.
+txt_theme_create_success: theme successfully created in
+txt_theming: Aparença
+txt_extand_error: Aquesta funció es pot aplicar només a un objecte a la vegada
+txt_threads: Fils
+txt_titlescolor: Titles color
+txt_to: to
+txt_toggle_browseflat: Toggle browse / flat view (show all)
+txt_toggle_historybookmarks: Toggle history/bookmarks
+txt_toolbarscolor: Color de les barres
+txt_tools: Eines
+txt_best: prova la millor configuració (més lent)
+txt_type: Tipus
+txt_level_ultra: Ultra
+txt_error_openfile: Unable to open the specified file
+txt_cl_hint: UNACE and UPX always run using console mode; list, test and benchmark tasks always run using GUI mode
+txt_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
+txt_units: unitats
+txt_unit_unknown: Unknown drive type
+txt_un7z_pw_untested: Untested
+txt_up: Up
+txt_update: Actualitza (si el fitxer existeix)
+txt_type_description_upx: UPX: compress executable files only
+txt_advfilters: Utilitza els filtres avançats
+txt_openfiles_hint: Use this option to include in the archive files open for writing by other applications (useful in backup tasks)
+txt_usenet: Usenet
+txt_user_name: Nom d'usuari; utilitza la forma usuari@DOMINI o DOMINI\usuari si és necessari.
+txt_using: En ús:
+txt_volumepea: Volume control
+txt_volume_size: Mida del volum
+txt_type_ext_uns: s'ha extret satisfactòriament
+txt_websearch: Cerca en línia
+txt_websites: Pàgines web
+txt_word: Word
+txt_write: Write:
+txt_ramdompw_hint: You can copy the random generated password from here
+txt_exe_hint: You can freely enter executable name and parameters for custom compression, and chose syntax's construction. Please note that you can also manually change command's syntax in "Console" tab.
+txt_pj_hint2: You can import the task's definition from the GUI frontend in the memo field below. Then, you can edit, launch or save it without changing or losing the task defined for the GUI frontend.
+txt_type_description_zip: ZIP: fast archiving/compression format, mainstream on Windows systems
+txt_zipcrypto_hint: ZipCrypto (legacy)
+
+=== end PeaZip text group ===
+
+=== PeaLauncher text group ===
+
+txt_6_9_remaining: restant
+txt_6_5_abort: Avorta
+txt_6_5_error: Error
+txt_6_5_no: No
+txt_6_5_warning: Avís
+txt_6_5_yes: Sí
+txt_6_5_yesall: Sí a tot
+txt_5_6_update: Comprova si hi ha actualitzacions
+txt_5_6_cml: Idioma del menú contextual del sistema
+txt_5_6_donations: Donacions
+txt_5_6_localization: Idioma
+txt_5_6_runasadmin: Executa com a administrador
+txt_5_6_help: Suport en línia
+txt_5_5_cancelall: Cancel·la-ho tot
+txt_5_3_details: Detalls
+txt_5_3_files: fitxers
+txt_5_3_folders: carpetes
+txt_5_3_info: Informació
+txt_5_3_list: Llista
+txt_5_3_os: Mida original
+txt_5_3_ps: Mida empaquetat
+txt_5_3_test: Verifica
+txt_5_0_extract: Extreu
+txt_5_0_from: des de
+txt_5_0_in: dins de
+txt_5_0_to: a
+txt_4_5_search: Cerca
+txt_4_0_drag: Arrossega aquí el fitxer a extreure, o
+txt_4_0_dragorselect: Arrossega'l aquí o selecciona un fitxer
+txt_4_0_select: selecciona un fitxer
+txt_3_6_selectdir: Selecciona un directori
+txt_3_5_close: Tanca
+txt_3_0_details: For more details, "Report" contains the task's log, and "Console" contains the task definition as command line.
+txt_3_0_hints: Hints about the error
+txt_3_0_arc: Some input files cannot be read (may be locked, not accessible or corrupted, volumes in multipart archive may be missing)
+txt_3_0_ext: The archive may require a different password for the current operation
+txt_2_8_oop: Open output path when task completes
+txt_2_7_validatefn: Operation stopped, invalid file name detected:
+txt_2_7_validatecl: Operation stopped, potentially dangerous command detected (i.e. command concatenation not allowed within the program):
+txt_2_6_open: Open archive
+txt_2_5_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
+txt_2_3_pw_errorchar_gwrap: quote character cannot be used by PeaLauncher in passwords under current system, please change password or chose Console mode in Backend binaries user interface in Options > Settings
+txt_2_3_renameexisting: Reanomena automàticament els fitxers existents
+txt_2_3_renameextracted: Reanomena automàticament els fitxers extrets
+txt_2_3_cancel: Cancel·la
+txt_2_3_encryption: Encriptació
+txt_2_3_extinnew: Extreu-ho en una nova carpeta
+txt_2_3_keyfile: Fitxer-clau
+txt_2_3_kf_not_found_gwrap: Keyfile cannot be found or read. Please chose a different Keyfile.
+txt_2_3_moreoptions: Més opcions...
+txt_2_3_nopaths: Sense camins
+txt_2_3_options: Opcions
+txt_2_3_overexisting: Sobreescriu els fitxers existents
+txt_2_3_pw: Contrasenya
+txt_2_3_skipexisting: Salta els fitxers existents
+txt_job_unknown: : S'ha trobat un error desconegut
+txt_stdjob: [l'animació s'aturarà quan es completi la tasca]
+txt_benchmarkjob: [system will respond slowly while running the benchmark (some minutes)]
+txt_defragjob: [will not respond while defragmenting, you can let it run in background]
+txt_consolejob: [task's feedback and detailed progress available in console window]
+txt_job1: 1: Avís: s'han produït errors lleus; p.ex. no s'han trobat alguns fitxers o estaven bloquejats
+txt_job127: 127: No s'ha pogut executar la operació sol·licitada
+txt_job2: 2: Error fatal
+txt_job255: 255: Task halted by the user
+txt_job7: 7: Error: línia de comandes incorrecta
+txt_job8: 8: Error: no hi ha prou memòria per a la operació sol·licitada
+txt_autoclose: Tanca la finestra quan finalitzi la tasca
+txt_crscale: Ràtio de compressió (com més baixa, millor):
+txt_console: Consola
+txt_benchscale: Core 2 Duo 6600 rating, equivalent MHz speed.
+txt_create: Crea
+txt_done: Fet:
+txt_nocl: Línia de comandes buida
+txt_error: Error:
+txt_explore: Explora
+txt_extto: Extreu a
+txt_halt: Halt system when task completes
+txt_halted: Halted:
+txt_hardware: hardware
+txt_high: prioritat alta
+txt_idle: idle priority
+txt_input: Entrada:
+txt_jpaused: Tasca pausada
+txt_jresumed: Tasca continuada
+txt_job_started: Tasca iniciada
+txt_jobstatus: Estat de la tasca:
+txt_jstopped: Task halted by the user
+txt_jobstopped: Task halted by the user; you can inspect the partial outcome clicking output path link.
+txt_job_success: Tasca completada satisfactòriament
+txt_lt: List/test
+txt_normal: prioritat normal
+txt_ok: OK
+txt_output: Sortida:
+txt_pause: Pausa
+txt_paused: Pausada,
+txt_p_high: Priority set to high
+txt_p_idle: Priority set to idle
+txt_p_normal: Priority set to normal
+txt_p_realtime: Priority set to real time
+txt_rating: Valoració:
+txt_rt: prioritat en temps real
+txt_report: Report
+txt_resume: Continua
+txt_priority: Fes clic aquí per establir la prioritat de la tasca
+txt_running: En curs,
+txt_isrunning: En curs...
+txt_saveas: Anomena i desa
+txt_savejob: Desa la definició de la tasca
+txt_savelog: Desa el registre de la tasca
+txt_software: programa
+txt_speedscale: Velocitat, escala logarítmica (com més alta, millor):
+txt_status: Estat
+txt_stop: Atura
+txt_bench: System benchmark
+txt_threads: Fils:
+txt_time: Temps:
+
+=== end PeaLauncher text group ===
+
+=== about text group ===
+
+EXTRACT ARCHIVE(S)
+From the system 
+- rightclick on the archive(s) and in system’s context menu click "Extract here" or "Extract here (smart new folder)" to extract with no further interaction. Smart new folder option takes care to create a new top level folder only if necessary, when the archives root contains more than one file or folder.
+- otherwise use "Extract..." menu entry for having more options: output path, password, extract files to a new directory, chose to skip, rename or overwrite existing files etc.
+
+Open an archive in PeaZip, i.e. with doubleclick, or drag an archive on PeaZip’s window or icon
+- click on "Extract" in toolbar or in context menu to extract only selected objects trough the confirmation dialog allowing to set all options (output path, password, naming policy, extract to a new directory etc)
+- drag files and folders to the desired destination, only selected content will be extracted (for more information see chapter about drag and drop in PeaZip)
+- click the quick extraction dropdown button on the right of “Extract” in the toolbar, it allows to directly extract the entire archive to most common destinations (skipping the confirmation dialog) and to set most important options; keyboard shortcuts: Ctrl+E (or F12) extracts the entire archive, asks for output directory; Ctrl+Alt+E extracts archive in its current folder; Ctrl+Shift+E extracts to desktop; Ctrl+Alt+Shift+E extracts to documents; Ctrl+0 extracts to previous path; Ctrl+1..8 extracts to path of bookmark 1..8 (if defined)
+
+Open PeaZip, select one or more archives and click “Extract” in toolbar or context menu, or use quick extraction destinations as explained at the previous point.
+
+EXTRACT ONLY SELECTED OBJECTS FROM THE ARCHIVE
+Open an archive in PeaZip, i.e. with doubleclick, or drag an archive on PeaZip’s window or icon
+- click "Extract" in toolbar: only selected items will be extracted
+- drag files and folders to the desired destination, only selected content will be extracted
+- rightclick and in “Extract” group of the context menu click “Extract selected” (to extract only selected items) or “Extract displayed” (to extract content of current directory or of current search filter)
+
+ENTER A PASSWORD TO BROWSE OR EXTRACT AN ARCHIVE
+Click on the padlock icon to enter a password and optionally a keyfile.
+The icon is featured both in PeaZip’s file browser’s status bar and in the archive extraction interface; once the password is set the icon will change color.
+
+CREATE ARCHIVE
+From the system
+- rightclick on objects to be archived and click on "Add to archive" in context menu or SendTo menu. It will open the archive creation confirmation dialog, more options are available in “Advanced” tab; click OK to create the archive.
+- alternatively, drag files/folders to PeaZip’s window or shortcut; the same archive creation interface will be shown.
+
+From PeaZip 
+- select objects to be archived and click on "Add" button; the same archive creation interface will be shown.
+
+ADD FILES/FOLDERS TO UPDATE EXISTING ARCHIVE
+Open an archive in PeaZip (i.e. with doubleclick, or drag an archive on PeaZip’s window or icon), then drag files and folders to be added in the archive (or click on "Add" button and use application's context menu to add objects to the archive).
+It will open the archive creation confirmation dialog, click OK to update the existing archive.
+
+CREATE ARCHIVE SPLIT IN SMALLER FILES
+While creating an archive as explained in previous points, click on “Single volume” dropdown menu to select a size for output files (volumes) the archive will be split in.
+Most common types of archives supports this option.
+
+CREATE ENCRYPTED ARCHIVE
+Click on the padlock icon to enter a password and optionally a keyfile; the icon is featured both in PeaZip’s file browser’s status bar and in archive creation interface.
+To hide names of files and directories contained in the archive check “Encrypt also filenames”, please note that it will be applied only if the archive will be created in a format supporting this function, like 7Z and ARC.
+Note that in archive creation interface, alongside the padlock icon, there is a warning to visually inform if encryption is set and if the current archive format supports encryption.
+
+CREATE SEPARATE ARCHIVES
+Add objects to be archived (with PeaZip’s "Add" button, or from system’s context menu or SendTo menu) and before confirming with "Ok" check "Add each object to a separate archive" option.
+
+CONVERT ARCHIVES
+From PeaZip select archives to be converted and click on "Convert" on toolbar or context menu, non-archive files and folders can be added as well, the difference being in archives being extracted before compression stage.
+Using the “Convert existing archives” switch in conjunction with “Add each object to a separate archive" (default) it performs a mass conversion of listed archives, without that switch archive conversion is meant to consolidate input data in a single archive, improving compression efficiency because it allows recompression of the original data from its uncompressed form.
+
+DIRECTLY CREATE ARCHIVES IN A SPECIFIED FORMAT AND WITH A CHOSEN COMPRESSION LEVEL
+Using “System integration” procedure in Options menu it is possible to enable context menu entries to directly add selected files/folders to a ZIP, 7Z or self extracting archive.
+For Zip and 7Z formats it is also possible to enable context menu entries to compress to fastest, normal or ultra level, bypassing the default compression level for the selected format.
+
+PASSWORD MANAGER
+Password manager is accessible from main menu, Tools > Password manager or from Password form, from drop down menu on the left of Password field.
+Saved passwords can be selected from the dropdown menu on the left of password filed in Password form, or can be copied from password manager to be used in any other application.
+If no master password is set for the password manager, the password list is accessible without prompting for authentication, otherwise passwords will not be displayed until the user correctly authenticates.
+
+CONFIGURE THE APPLICATION
+Options > Localization (and in Options > Settings, first tab) allows to set application’s language.
+Options > Settings allows to edit applications’ settings
+Options > Theme allows to change application’s icons and appearance
+Options > System integration starts a wizard to configure file associations, context menu and SendTo menu entries (on Windows)
+Organize menu contains entry to customize, enable or disable browser’s features, like toolbar, address bar, navigation bar, etc
+
+F1 	help
+F2 	rename file(s) / Ctrl+F2 copy selected to / Shift+F2 move selected to
+F3	search (recursivity option is remembered) / Ctrl+F3 start as non recursive (search here) / Shift+F3 recursive / Alt+F3 system search
+F4 	show navigation popup menu / Ctrl+Shift+F4 browse computer root / Ctrl+F4 browse desktop / Shift+F4 browse home
+F5 	refresh
+F6 	toggle browse/flat view
+F7 	add to bookmarks / Ctrl+F7 open in a new instance of PeaZip / Shift+F7 open command prompt in selected path / Alt+F7 explore selected path
+F8 	browse first item in bookmarks list (Ctrl, second, Shift, third)
+F9 	set password/keyfile / Shift+F9 password manager / Ctrl+F9 create keyfile or random password / Ctrl+Shift+F9 set advanced filters
+F10 	menu / Ctrl+F10 run as different user / Alt+F10 run as administrator (Windows Vista and newer systems)
+F11 	toggle full screen mode / Ctrl+F11 immersive
+F12 	extract all to...
+
+ABOUT PEAZIP
+
+PeaZip is an open source file and archive manager: cross platform, available as portable and installable software for 32 and 64 bit Windows (9x, 2k, XP, Vista) and Linux (PeaZip is a desktop neutral application).
+
+PeaZip allows to apply powerful multiple search filters to archive's content; create and extract multiple archives at once; create self-extracting archives; export task definition as command line; save archiving and extraction layouts; bookmark archives and folders; scan and open with custom applications compressed and uncompressed files etc...
+
+Other features: strong encryption, robust file copy, split/join files (file span), secure data deletion, compare, checksum and hash files, system benchmark, generate random passwords and keyfiles.
+
+Downloads: https://peazip.github.io
+Learn more: https://peazip.github.io/peazip-free-archiver.html
+Support: https://peazip.github.io/peazip-help.html
+FAQ: https://peazip.github.io/peazip-help-faq.html
+
+Many thanks to all people contributing to PeaZip project's growth developing Open Source software components used in this application (see website for complete list), and to all users contributing with feedback, experience and advices.

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -71,7 +71,7 @@ txt_7_6_setcurdef: Estableix l'ubicació actual com a ubicació d'extracció per
 txt_7_6_setdef: Estableix una ubicació d'extracció per defecte
 txt_7_6_tadvanced: Sincronitza l'arbre de l'arxiu, manté els elements visitats
 txt_7_6_tsimple: Sincronitza l'arbre de l'arxiu, simple
-txt_7_6_tacolor: Accent de text
+txt_7_6_tacolor: Color del text
 txt_7_5_always: Sempre
 txt_7_5_ask: Pregunta
 txt_7_5_autoclosesingle: Tanca automàticament després de l'extracció si no es realitza cap acció de navegació
@@ -313,7 +313,7 @@ txt_5_0_pictures: Imatges
 txt_5_0_removeall: Elimina-ho tot
 txt_5_0_resetbookmarks: Vols reestablir els preferits? (Els preferits es poden personalitzar a Preferits > Organitza)
 txt_5_0_sh: Historial de la sessió
-txt_5_0_skip: Omet enumerar el contingut dels directoris a la maquetació
+txt_5_0_skip: Omet enumerar el contingut dels directoris a la vista
 txt_5_0_videos: Vídeos
 txt_4_9_frame: Marc
 txt_4_9_listth: Llista i miniatures
@@ -400,11 +400,11 @@ txt_3_7_donations: Donacions
 txt_3_7_nameasparent: Anomeneu l'arxiu com la carpeta on es troba l'element seleccionat, si s'afegeixen diversos elements
 txt_3_7_tracker: Suggeriments, errors, sol·licituds
 txt_3_7_sort: Ordena per
-txt_3_7_swapbars: Barra d'eines d'intercanvi / barra d'adreces
+txt_3_7_swapbars: Intercanvia la barra d'eines i la barra d'adreces
 txt_3_7_themedbars: Barres temàtiques
-txt_3_6_ignoredd: Ignoreu sempre els camins per a l'extracció d'arrossegar i deixar anar
+txt_3_6_ignoredd: Ignora sempre els camins per a l'extracció d'arrossegar i deixar anar
 txt_3_6_close: Tanca
-txt_3_6_resetapps: Voleu restablir les aplicacions (grup personalitzable de programes i scripts per obrir fitxers, substituint les associacions de fitxers del sistema)?
+txt_3_6_resetapps: Vols restablir les aplicacions (grup personalitzable de programes i scripts per obrir fitxers, substituint les associacions de fitxers del sistema)?
 txt_3_6_ethemes: Temes existents
 txt_3_5_td: Descarrega temes
 txt_3_5_managecustomthemes: Administrador de temes
@@ -499,7 +499,7 @@ txt_2_7_eu: Extreu tipus de fitxers no suportats, especificant una utilitat d'ex
 txt_2_7_clipboard: Porta-retalls
 txt_2_7_goarclayout: Vés a la vista de compressió
 txt_2_7_goextlayout: Vés a la vista d'extracció
-txt_2_7_ok: OK
+txt_2_7_ok: D'acord
 txt_2_7_drag_archive: vols obrir el fitxer com a nou arxiu? (clica "No" per afegir el fitxer a la finestra actual d'arxivament)
 txt_2_7_oop: Obra la ubicació d'extracció quan finalitzi el procés
 txt_2_7_validatefn: L'operació s'ha aturat, s'ha detectat un nom de fitxer no vàlid:
@@ -513,7 +513,7 @@ txt_2_7_exthint: Arrossega arxius comprimits aquí per extreure'ls, o fes clic a
 txt_2_7_setadvf: Estableix filtres avançats
 txt_2_7_selpath: Camí de l'element seleccionat
 txt_2_7_separateerror: No es poden importar les ordres de la tasca mentre la opció "Afegeix cada objecte a un arxiu separat" està activada, ja que la tasca s'executa com a múltiples ordres diferents
-txt_2_7_noinput: La maquetació és buida: utilitza Afegeix fitxers o Carrega disseny per omplir la llista d’arxius que s’extreuran
+txt_2_7_noinput: La vista és buida: utilitza "Afegeix fitxers" o "Carrega una vista" per omplir la llista d’arxius que s’extreuran
 txt_2_7_dirsize: No es comprova la mida del contingut de les carpetes per calcular la mida total
 txt_2_7_un7z_browse_flat: prova la vista plana (F6)
 txt_2_7_updating: S'està actualitzant l'arxiu existent
@@ -528,12 +528,12 @@ txt_2_5_cannotrun: No es pot executar
 txt_2_5_custeditors: Editors personalitzats, reproductors, antivirus, etc ... (sobreescriu les associacions de fitxers del sistema)
 txt_2_5_delete: Suprimeix
 txt_2_5_delete_fromarchive: Suprimeix de l'arxiu
-txt_2_5_langflag: Display archived object's name as UTF-8 text; uncheck to replace extended characters with "?"
-txt_2_5_encpj: Encode task definition as UTF-8 text
-txt_2_5_execommand: Executable or command
+txt_2_5_langflag: Mostra el nom de l'objecte arxivat com a text UTF-8; desmarca aquesta opció per substituir els caràcters especials per "?"
+txt_2_5_encpj: Codifica la definició de tasques com a text UTF-8
+txt_2_5_execommand: Executable o ordre
 txt_2_5_help: Ajuda
-txt_2_5_langhint: Hint: replacing extended characters with "?" jolly character can improve syntax if archive's character set cannot be successfully converted on the current machine
-txt_2_5_mini_help: Tutorial en el teu idioma
+txt_2_5_langhint: Suggeriment: reemplaçar els caràcters especials amb el comodí "?" pot millorar la sintaxi si la codificació de caràcters de l'arxiu no és compatible amb el sistema operatiu
+txt_2_5_mini_help: Tutorial d'ajuda
 txt_2_5_offline_help: Ajuda del PeaZip
 txt_2_5_tray: Minimitza a la safata del sistema
 txt_2_5_remove: Elimina
@@ -543,7 +543,7 @@ txt_2_5_strafter: Cadena alfanumèrica després del nom d'entrada
 txt_2_5_strbefore: Cadena alfanumèrica abans del nom d'entrada
 txt_2_5_encoding: Codificació del text
 txt_2_5_nopw: aquest tipus d'arxius no suporten l'encriptació
-txt_2_4_draghint: [drag to Explorer with enabled Address bar]
+txt_2_4_draghint: [arrossega a l'Explorador amb la barra d'adreces activa]
 txt_2_4_tb: Adapta els botons de la barra d'eines (requereix reiniciar el PeaZip)
 txt_2_4_adding: Afegint
 txt_2_4_advclip: Desar diverses seleccions al porta-retalls, es neteja en enganxar
@@ -560,14 +560,14 @@ txt_2_4_hexp: Previsualització hex
 txt_2_4_operation: Operació
 txt_2_4_path: la ubicació no es pot escriure (p. ex. només lectura). Vols seleccionar una altra ubicació d'extracció escrivible?
 txt_2_4_removefromclipboard: Elimina del porta-retalls
-txt_2_4_stdclip: Standard: keep a single selection in clipboard, clear cut operations on paste
+txt_2_4_stdclip: Estàndard: mantén una única selecció al porta-retalls, esborra les operacions de retall en enganxar
 txt_2_4_totalmem: memòria total
 txt_2_4_gvideo: Vídeo
 txt_2_4_wbook: Wikibook
 txt_2_4_wnews: Wikinews
 txt_2_4_wsrc: Wikisource
 txt_2_4_wdict: Wiktionary
-txt_2_3_pw_errorchar: quote character is not recommended to be used in passwords (for PeaZip and scripts). If you need to create or extract an archive with this password you can dismiss the message and you will be asked to enter the password interactively in console.
+txt_2_3_pw_errorchar: no es recomana utilitzar les cometes a les contrasenyes (al PeaZip i als scripts). Si necessites crear o extreure un arxiu amb aquesta contrasenya, pots ometre aquest missatge i se't demanarà que introdueixis la contrasenya de forma interactiva des de la consola.
 txt_2_3_envstr: Mostra les variables d'entorn
 txt_2_3_never_pw: No demanis cap contrasenya
 txt_2_3_home: Directori de l'usuari
@@ -575,24 +575,24 @@ txt_2_3_on_pw: Quan s'executin operacions d'extracció, llistat o verificació d
 txt_2_3_test_pw100: Verifica si es poden encriptar, arxius <100MB
 txt_2_3_test_pw: Verifica si es poden encriptar (pot ser un procés lent)
 txt_exclude_recourse: Recursiu (explou les subcarpetes)
-txt_action_extopen: Acció de "Extreu i obre amb l'aplicació associada del sistema"
+txt_action_extopen: Acció de "Extreu i obre amb l'aplicació associada"
 txt_error_passwordnotmatch: Els camps de contrasenya i confirmació de la contrasenya no coincideixen, si us plau, corregeir-los
-txt_action_preview: "Preview with associated application" action
-txt_preview_hint: "Preview" action perform the same task as "Extract and open" but to a temporary path in output directory, automatically removed when the archive is closed.
+txt_action_preview: Acció de "Previsualitza amb l'aplicació associada"
+txt_preview_hint: L'acció "Previsualitza" realitza la mateixa funció que "Extreu i obre", però en un directori temporal que s'elimina automàticament quan es tanca l'arxiu.
 txt_better: (millor)
 txt_default2: (per defecte)
 txt_faster: (més ràpid)
 txt_fastermem: (més ràpid, menys memòria)
-txt_tempdir: (PeaZip's temporary work folder)
-txt_stream: (set by "Stream control")
+txt_tempdir: (carpeta de treball temporal del PeaZip)
+txt_stream: (segons el "Control de flux")
 txt_slowermem: (més lent, més memòria)
-txt_store: (store, fastest)
+txt_store: (emmagatzema, més ràpid)
 txt_newfolder: (en una carpeta nova)
 txt_7z_exitcodeunknown: : Error de tasca desconegut
 txt_list_isfolder:  [carpeta]
 txt_none: <cap>
 txt_fd: 1.44 MB Disquet
-txt_7z_exitcode1: 1: Warning: non fatal error(s); i.e. some files missing or locked
+txt_7z_exitcode1: 1: Avís: no s'han produït errors fatals, però alguns falten alguns fitxers o estan bloquejats
 txt_attach10: adjunt de 10 MB
 txt_7z_exitcode2: 2: S'ha produït un error fatal
 txt_7z_exitcode255: 255: L'usuari ha interromput la tasca
@@ -602,13 +602,13 @@ txt_attach5: adjunt de 5 MB
 txt_cd650: 650 MB CD
 txt_7z_exitcode7: 7: Error: s'ha obtingut una ordre incorrecta
 txt_cd700: 700 MB CD
-txt_type_description_7z: 7Z: feature rich archive format with high compression ratio
+txt_type_description_7z: 7Z: format amb una alta capacitat de compressió i moltes característiques de configuració
 txt_dvddl: 8.5 GB DVD DL
 txt_7z_exitcode8: 8: Error: no hi ha prou memòria disponible per a la operació sol·licitada
-txt_abort: Abort scheduled file copy/move operations?
+txt_abort: Vols cancel·lar les operacions programades de còpia i desplaçament de fitxers?
 txt_about: Sobre
 txt_action: Acció
-txt_action_hint: Action on open or preview with associated application
+txt_action_hint: Acció en obrir o previsualitzar amb l'aplicació associada
 txt_add: Afegeix
 txt_add_existing_archive: Afegeix (si l'arxiu existeis)
 txt_add_archive: Afegeix un arxiu
@@ -628,24 +628,24 @@ txt_all_date: Data
 txt_all_psize: Mida del fitxer empaquetat
 txt_all_attributes: Mateixos atributs
 txt_all_size: Mida del fitxer
-txt_error_input_upx: allows a single executable file as input
+txt_error_input_upx: permet un únic fitxer executable com a entrada
 txt_always_pw: Pregunta'm sempre una contrasenya
 txt_ignore_ext: Ignora sempre els camins per "Extreu i..."
 txt_ignore_disp: Ignora sempre els camins per "Extreu els visibles..."
 txt_ignore_sel: Ignora sempre els camins per "Extreu els seleccionats..."
-txt_key_hint: Append keyfile's hash to password; the archive can be decrypted by PeaZip and other applications following the same standard, or entering the hash as part of the password
-txt_timestamp: Append timestamp to name
+txt_key_hint: Afegeix el hash del fitxer de xifratge a la contrasenya. El PeaZip i altres aplicacions poden desxifrar l'arxiu seguint el mateix estàndard o introduint el hash com a part de la contrasenya
+txt_timestamp: Afegeix la marca horària al nom
 txt_appoptions: Opcions de l'aplicació
 txt_type_description_arc: ARC: arxivador experimental, potent, eficient i amb moltes característiques
 txt_archive: Arxiu
-txt_un7z_browse_ok: archive browsed successfully
-txt_interface: Archive browser interface
-txt_archivecreation: Archive creation
-txt_tarbefore_hint: Archive data in TAR format before than in specified type.
-txt_archive_hint: Archive, compress, split and keep private files, folders and volumes
-txt_compressionratio_hint: Archive's compression ratio
+txt_un7z_browse_ok: arxiu explorat amb èxit
+txt_interface: Interfície del navegador d'arxius
+txt_archivecreation: Creació de l'arxiu
+txt_tarbefore_hint: Uneix-ho tot en un fitxer TAR abans de comprimir-ho al format especificat.
+txt_archive_hint: Arxiva, comprimeix, divideix i desa fitxers, carpetes i volums privats
+txt_compressionratio_hint: Ràtio de compressió de l'arxiu
 txt_archiving: Arxivant:
-txt_cl_long: Arguments seem exceeding the maximum size that can be passed by PeaZip frontend, please select less input files (i.e. select dirs instead of single files)
+txt_cl_long: Els arguments semblen superar la mida màxima que pot passar la interfície gràfica del PeaZip, selecciona menys fitxers d'entrada (és a dir, selecciona carpetes en lloc de fitxers individuals)
 txt_overwrite_askbefore: Pregunta'm abans de substituir fitxers (a la consola)
 txt_associated: Aplicació associada
 txt_attributes: Atributs
@@ -654,19 +654,19 @@ txt_ren_existing: Reanomena automàticament els fitxers existents
 txt_ren_extracted: Reanomena automàticament els fitxers extrets
 txt_autofolder: Vols crear una nova carpeta automàticament per extreure-hi l'arxiu a dins?
 txt_back: Endarrera
-txt_backend: Backend binaries user interface
-txt_backupexe: Backup executable (recommended)
+txt_backend: Interfície d'usuari dels binaris del backend
+txt_backupexe: Conserva l'executable (recomanat)
 txt_bettercompression: millor compressió
 txt_blogs: Blogs
 txt_blowfish: Blowfish448 (blocs de 64 bit)
 txt_bookmarks: Preferits
 txt_browse: Navega
 txt_browser: Navegador
-txt_aborted_error: Browsing archive stopped, it would take too much time. You can narrow the selection using search (F3) or avoiding Flat view mode (F6). You can directly extract, list or test the archive.
+txt_aborted_error: S'ha aturat la navegació de l'arxiu perquè trigaria massa temps. Podeu restringir la selecció mitjançant la cerca (F3) o evitant el mode de visualització plana (F6). Podeu extreure, llistar o verificar directament l'arxiu.
 txt_list_browsing: Navegant per
 txt_archive_root: Browsing: archive's root
 txt_type_description_bzip2: BZip2: quite powerful compression, average speed
-txt_pw_empty: Please provide a password (or a keyfile)
+txt_pw_empty: Si us plau, proporciona una contrasenya (o un fitxer de xifratge)
 txt_add_error: Cannot add/update or delete object(s). The archive is not writeable, or cannot support this operation. Editing non-canonical archive types can be enabled in Archive manager options.
 txt_un7z_browse_failure: no es pot navegar per l'arxiu
 txt_list_error: Cannot list archive's content, please check if the archive is password protected or corrupted.
@@ -750,8 +750,8 @@ txt_exclude_hint: Exclude file(s), one per line; use * and ? wildcards; " and ' 
 txt_exclusion_recourse: Filtres d'exclusió amb subdirectoris recursius
 txt_exclusion: Exclou
 txt_exe: Executable
-txt_overwrite_qry: exists in destination path; overwrite with file(s) with same name from source path? (Cancel: skip copying this object)
-txt_confirm_overwrite: exists; overwrite it? (no to skip)
+txt_overwrite_qry: existeix a la ubicació de destinació. Vols substituir els fitxers que s'anomenen igual? (Cancel·la per ometre els fitxers que s'anomenen igual)
+txt_confirm_overwrite: ja existeix. Vols sobreesciure'l? (Clica "No" per ometre'l)
 txt_explore_outpath: Explora la ubicació d'extracció
 txt_explore_path: Explora la ubicació
 txt_ext: Ext:
@@ -802,7 +802,7 @@ txt_multithreading: Processament en paral·lel genèric
 txt_go_browser: Vés a l'explorador de fitxers
 txt_go_path: Explora la ruta (PeaZip)
 txt_guicl: Gràfic + consola
-txt_guipealauncher: Gràfic: wrapped by PeaLauncher
+txt_guipealauncher: Gràfic: proporcionat pel PeaLauncher
 txt_graphic: Carpeta dels gràfics
 txt_gridaltcolor: Alterna el color de la quadrícula
 txt_gridrowheight: Altura de les files de la quadrícula
@@ -939,7 +939,7 @@ txt_un7z_browse_pw: potser es requereix una contrasenya
 txt_un7z_browse_pw_other: potser la contrasenya és incorrecta
 txt_paste: Enganxa
 txt_path: Camí
-txt_pea_appcolor: Application accent
+txt_pea_appcolor: Color de l'aplicació
 txt_pea_textcolor: Color del text del PeaZip
 txt_type_description_pea: PEA: format d'arxivament basat en la seguretat i de compressió ràpida
 txt_peazip_new: PeaZip (instància nova)
@@ -947,24 +947,24 @@ txt_peazip_help: Suport en línia
 txt_peazip_web: Lloc web del PeaZip
 txt_performall: Tots els algoritmes
 txt_name_provide: Els caràcters \ / : * ? ' " < > | no es permeten als noms dels fitxers
-txt_upxorstrip: Please chose Strip and/or UPX on the binary
-txt_not_removable_file: Please close file in use, in order to allow PeaZip to remove it:
-txt_not_removable: Please close files in use, in order to allow PeaZip to remove the folder:
+txt_upxorstrip: Si us plau, tanca el Strip i/o l'UPX al binari
+txt_not_removable_file: Si us plau, tanca el fitxer obert per tal que el PeaZip pugui eliminar-lo:
+txt_not_removable: Si us plau, tanca els fitxers oberts per tal que el PeaZip pugui eliminar la carpeta:
 txt_custom_executable_missing: Please provide the custom executable's name
 txt_type_unsupported_select: Si us plau, selecciona un tipus de fitxer suportat:
 txt_no_theme_name: Si us plau, especifica el nom del tema
 txt_please_wait: Si us plau, espera un moment...
-txt_copy_wait: Please wait currently scheduled file copy/move operations to complete before scheduling other operations of the same type
+txt_copy_wait: Si us plau, espera que es completin les operacions de còpia i desplaçament de fitxers programades actualment abans de programar altres operacions del mateix tipus
 txt_previewwith: Previsualitza amb...
-txt_projectadmin: Project administrator:
-txt_type_description_quad: BALZ/QUAD: high-performance ROLZ-based file compressors
+txt_projectadmin: Administrador del projecte:
+txt_type_description_quad: BALZ/QUAD: compressor de fitxers d'alt rendiment basat en ROLZ
 txt_quickdelete: Eliminació ràpida
 txt_quit: Surt
 txt_unit_ram: disc RAM
 txt_read: Lectura:
 txt_recentarchives: Arxius recents
-txt_rr_hint: Recovery records allows to try to correct archives in case of data corruption
-txt_search_refine: Refine search filter, accepts ? and * wildcards
+txt_rr_hint: Els registres de recuperació permeten intentar corregir arxius en cas de corrupció de dades
+txt_search_refine: Refina els filtres de cerca, accepta els caràcters comodins ? i *
 txt_fefreshf5: Actualitza (F5)
 txt_release: release:
 txt_unit_removable: Unitat extraïble
@@ -976,25 +976,25 @@ txt_caption_repair: Repara
 txt_restartrequired2: requereix reiniciar l'aplicació per aplicar els canvis
 txt_reset: Reestableix
 txt_reset_archivename: Reestableix el nom del fitxer
-txt_hardreset: Reset bookmarks
-txt_reset_theme: Reset to embedded theme
-txt_restore_att: restore original attributes
+txt_hardreset: Reestableix els preferits
+txt_reset_theme: Reestableix el tema original
+txt_restore_att: reestableix els atributs originals
 txt_run_as: Executa-ho com a (no es pot utilitzar un usuari amb la contrasenya en blanc)
 txt_run_as2: Executa-ho com un usuari diferent
-txt_sample: Sample: 
+txt_sample: Exemple: 
 txt_saveas: Anomena i desa
 txt_savehistory: Desa l'historial
-txt_save_infolder: Save in folder (auto)
+txt_save_infolder: Desa en una carpeta (automàticament)
 txt_savejob: Desa la definició de la tasca
 txt_savejobdefinition: Desa la definició de la tasca
 txt_savejobdefinition_hint: Desa la definició de la tasca com a text pla; la podràs utilitzar en els teus scripts
-txt_savelayout: Desa la maquetació
-txt_save_winstate: Save main window state
+txt_savelayout: Desa la vista
+txt_save_winstate: Desa l'estat de la finestra principal
 txt_search: Cerca (recursivament, pot tardar un cert temps)
 txt_searchanddrag: Cerca i arrossega aquí
 txt_searchfor: Cerca
 txt_nrsearch: Cerca aquí (no recursiu)
-txt_search_hint: Search in archive's subdirectories for matches with filter(s)
+txt_search_hint: Cerca coincidències amb els filtres als subdirectoris de l'arxiu
 txt_search_web: Cerca en línia
 txt_list_searching: Cercant...
 txt_securedelete: Eliminació segura
@@ -1031,7 +1031,7 @@ txt_split_file: Divideix el fitxer
 txt_list_nostats: no hi ha estadístiques disponibles
 txt_status: Estat
 txt_level_store: Store
-txt_stream_control: Stream control
+txt_stream_control: Control de flux
 txt_strip: Strip before UPX (recommended)
 txt_keyfile_created: Fitxer de xifratge creat satisfactòriament com a:
 txt_suggestpw: Crea una contrasenya aleatòria
@@ -1050,11 +1050,11 @@ txt_testpw: Verifica la contrasenya / fitxer de xifratge
 txt_testsel: Verifica els objectes seleccionats
 txt_col_hint: The color should be chosen in order to integrate well with icon colors and to other GUI's elements
 txt_bookmarks_hint: The complete and editable list of bookmarks is available in the file browser interface, clicking on the "More controls" icon and on "Toggle history/bookmarks"
-txt_archive_noinput_tolist: The layout is empty: please use Add file(s), Add folder(s) or Load Layout to populate the archive's layout
+txt_archive_noinput_tolist: La vista és buida: utilitza "Afegeix fitxers" o "Carrega una vista" per omplir la llista d’arxius
 txt_theme: Tema
 txt_icons_found: Tema carregat satisfactòriament.
 txt_themename: Nom del tema
-txt_icons_not_found: Theme not loaded correctly. Try to switch to the default theme, or to a known working one.
+txt_icons_not_found: El tema no s'ha carregat correctament. Proveu de canviar al tema predeterminat o a un que sapigueu que funciona correctament.
 txt_theme_create_success: creat satisfactòriament a
 txt_theming: Aparença
 txt_extand_error: Aquesta funció es pot aplicar només a un objecte a la vegada
@@ -1068,17 +1068,17 @@ txt_tools: Eines
 txt_best: prova la millor configuració (més lent)
 txt_type: Tipus
 txt_level_ultra: Ultra
-txt_error_openfile: Unable to open the specified file
-txt_cl_hint: UNACE and UPX always run using console mode; list, test and benchmark tasks always run using GUI mode
-txt_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
+txt_error_openfile: No és possible obrir el fitxer especificat
+txt_cl_hint: L'UNACE i l'UPX sempre s'executen en la modalitat de consola. Les llistes, verificacions i proves de rendiment del sistema sempre s'executen mitjançant la interfície gràfica.
+txt_ace_missing: Falta el connector UNACE; per gestionar arxius ACE, podeu descarregar el connector del lloc web del PeaZip (en ser un codi tancat d'UNACE, el connector no es distribueix a,b el paquet base)
 txt_units: unitats
 txt_unit_unknown: Tipus d'unitat desconeguda
-txt_un7z_pw_untested: Untested
+txt_un7z_pw_untested: No verificat
 txt_up: Amunt
 txt_update: Actualitza (si el fitxer existeix)
-txt_type_description_upx: UPX: compress executable files only
+txt_type_description_upx: UPX: només comprimeix fitxers executables
 txt_advfilters: Utilitza els filtres avançats
-txt_openfiles_hint: Use this option to include in the archive files open for writing by other applications (useful in backup tasks)
+txt_openfiles_hint: Utilitzeu aquesta opció per incloure a l'arxiu els fitxers oberts des d’altres aplicacions (útil en tasques de còpia de seguretat)
 txt_usenet: Usenet
 txt_user_name: Nom d'usuari; utilitza la forma usuari@DOMINI o DOMINI\usuari si és necessari.
 txt_using: En ús:
@@ -1089,11 +1089,11 @@ txt_websearch: Cerca en línia
 txt_websites: Pàgines web
 txt_word: Word
 txt_write: Escriptura:
-txt_ramdompw_hint: You can copy the random generated password from here
-txt_exe_hint: You can freely enter executable name and parameters for custom compression, and chose syntax's construction. Please note that you can also manually change command's syntax in "Console" tab.
-txt_pj_hint2: You can import the task's definition from the GUI frontend in the memo field below. Then, you can edit, launch or save it without changing or losing the task defined for the GUI frontend.
-txt_type_description_zip: ZIP: fast archiving/compression format, mainstream on Windows systems
-txt_zipcrypto_hint: ZipCrypto (legacy)
+txt_ramdompw_hint: Pots copiar la contrasenya generada aleatòriament des d’aquí
+txt_exe_hint: Podeu introduir el nom i els paràmetres d'execució de la compressió personalitzada i escollir la construcció de la sintaxi. Tingueu en compte que també podeu canviar manualment la sintaxi de l'ordre a la pestanya "Consola".
+txt_pj_hint2: Podeu importar la definició de la tasca des de la interfície gràfica d’usuari al camp següent. A continuació, podeu editar-lo, iniciar-lo o desar-lo sense canviar ni perdre la tasca definida per a la interfície gràfica.
+txt_type_description_zip: ZIP: format d'arxivament i compressió ràpid, habitual als sistemes Windows
+txt_zipcrypto_hint: ZipCrypto (abandonat)
 
 === end PeaZip text group ===
 
@@ -1131,16 +1131,16 @@ txt_4_0_dragorselect: Arrossega'l aquí o selecciona un fitxer
 txt_4_0_select: selecciona un fitxer
 txt_3_6_selectdir: Selecciona un directori
 txt_3_5_close: Tanca
-txt_3_0_details: For more details, "Report" contains the task's log, and "Console" contains the task definition as command line.
-txt_3_0_hints: Hints about the error
-txt_3_0_arc: Some input files cannot be read (may be locked, not accessible or corrupted, volumes in multipart archive may be missing)
-txt_3_0_ext: The archive may require a different password for the current operation
+txt_3_0_details: Per a més informació, l'"Informe" conté el registre de la tasca i "Consola" conté la definició de la tasca com a seqüència d'ordres.
+txt_3_0_hints: Suggeriments sobre l'error
+txt_3_0_arc: Alguns fitxers d'entrada no s'han pogut llegir (potser estan bloquejats, no són accessibles o estan corromputs, o bé, potser falten alguns volums d'un arxiu multivolum)
+txt_3_0_ext: L'arxiu deu requerir una contrasenya diferent per executar aquesta operació
 txt_2_8_oop: Obre l'ubicació de sortida quan finalitzi la tasca
 txt_2_7_validatefn: S'ha aturat l’operació, s'ha detectat un nom de fitxer invàlid:
 txt_2_7_validatecl: S'ha aturat l’operació, s'ha detectat una ordre potencialment perillosa (p. ex. ordres concatenades no permeses al programa):
 txt_2_6_open: Obre un arxiu
-txt_2_5_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
-txt_2_3_pw_errorchar_gwrap: quote character cannot be used by PeaLauncher in passwords under current system, please change password or chose Console mode in Backend binaries user interface in Options > Settings
+txt_2_5_ace_missing: Falta el connector UNACE; per gestionar arxius ACE, podeu descarregar el connector del lloc web del PeaZip (en ser un codi tancat d'UNACE, el connector no es distribueix a,b el paquet base)
+txt_2_3_pw_errorchar_gwrap: les cometes no es poden utilitzar en contrasenyes del PeaLauncher en aquest sistema operatiu, si us plau, canvia la contrasenya o utilitza el mode Consola a Binaris del Backend dins de Opcions > Configuració
 txt_2_3_renameexisting: Reanomena automàticament els fitxers existents
 txt_2_3_renameextracted: Reanomena automàticament els fitxers extrets
 txt_2_3_cancel: Cancel·la
@@ -1177,7 +1177,7 @@ txt_explore: Explora
 txt_extto: Extreu a
 txt_halt: Apaga l'ordinador en finalitzar la tasca
 txt_halted: Interromput:
-txt_hardware: hardware
+txt_hardware: maquinari
 txt_high: prioritat alta
 txt_idle: prioritat quan estigui inactiu
 txt_input: Entrada:
@@ -1208,7 +1208,7 @@ txt_isrunning: En curs...
 txt_saveas: Anomena i desa
 txt_savejob: Desa la definició de la tasca
 txt_savelog: Desa el registre de la tasca
-txt_software: programa
+txt_software: programari
 txt_speedscale: Velocitat, escala logarítmica (com més alta, millor):
 txt_status: Estat
 txt_stop: Atura

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -14,77 +14,77 @@ txt_8_2_ta: Últim accés
 txt_8_2_tc: Creat el
 txt_8_2_keep: Conserva els fitxers
 txt_8_2_tm: Modificat el
-txt_8_2_skipet: Skip testing for encryption
+txt_8_2_skipet: Omet la verificació per a l'encriptació
 txt_8_2_alltimes: Emmagatzema totes les marques horàries
 txt_8_2_supportedby: Suportat per
-txt_8_1_preparse: Always pre-parse archives
+txt_8_1_preparse: Pre-analitzar sempre els arxius
 txt_8_1_bo: Optimització del navegador
-txt_8_1_bop: Browser optimization options can be set from Options > Settings, General tab, in order to allow browser to display archives containing a very large number of items.
-txt_8_1_nopreparse: Do not pre-parse archives
+txt_8_1_bop: Les opcions d’optimització del navegador es poden configurar a Opcions >  Configuració, pestanya General, per tal de permetre al navegador mostrar arxius que contenen un gran nombre d’elements.
+txt_8_1_nopreparse: No analitzeu prèviament els arxius
 txt_8_1_ed: error(s) detectats.
-txt_8_1_togglearc: Listing flat view of archive content may take long time, continue anyway?
-txt_8_1_preparsehint: Optimize performances limiting pre-parsing of large archives. Pre-parsing is meant to detect in advance possible issues in archive content.
+txt_8_1_togglearc: La visualització plana del contingut de l'arxiu pot tardar molt de temps, vols continuar de totes maneres?
+txt_8_1_preparsehint: Optimitza el rendiment a base de limitar el pre-anàlisi dels arxius grans. El pre-anàlisi pretén detectar amb antelació possibles problemes en el contingut de l'arxiu.
 txt_8_1_slow: Lent
 txt_8_1_vslow: Molt lent
 txt_8_1_volumes: volums
 txt_8_0_altcol: Alterna el color de la quadrícula
-txt_8_0_forcebrowse: Browse non-canonical archive types (containers, disk images, installers,...)
+txt_8_0_forcebrowse: Cerca tipus d’arxius no canònics (contenidors, imatges de disc, instal·ladors, ...)
 txt_8_0_commonalgo: Algoritmes comuns
-txt_8_0_forceconvert: Convert non-canonical archive types
-txt_8_0_defaultactionhint: Default action double-clicking a file associated with PeaZip from the system
-txt_8_0_defaultaction: Default action on start-up
-txt_8_0_enableextand: Enable "Extract and open with" submenu
-txt_8_0_forcetyping: Force typing passwords interactively
-txt_8_0_setpwopt: Configura les opcions de contrasenya / fitxer-clau
+txt_8_0_forceconvert: Converteix els tipus d’arxius no canònics
+txt_8_0_defaultactionhint: Acció per defecte en fet doble clic des del sistema sobre un fitxer associat al PeaZip
+txt_8_0_defaultaction: Acció predeterminada en iniciar
+txt_8_0_enableextand: Activa el submenú "Extreu i obre amb"
+txt_8_0_forcetyping: Força l’escriptura de contrasenyes de manera interactiva
+txt_8_0_setpwopt: Configura les opcions de contrasenya i dels fitxers de xifratge
 txt_8_0_forcetypinghelp: Will run backend binaries in console, cannot browse archives with encrypted filenames. Allows to create scripts that will not run unattended but rather ask user interactively for password.
 txt_7_9_spacing: Espaiat
 txt_7_9_zooming: Zooming
 txt_7_8_changelocalization: Canvia l'idioma del PeaZip
 txt_7_8_custext: Extensió personalitzada
-txt_7_8_destexistfile: Destination already contains processed files. Replace files with same name?
-txt_7_8_dd: Drag and Drop
+txt_7_8_destexistfile: La destinació ja conté fitxers processats. Vols substituir-los?
+txt_7_8_dd: Arrossegar i deixar anar
 txt_7_8_priorityhigh: Alta
-txt_7_8_priorityidle: Idle
+txt_7_8_priorityidle: Quan estigui inactiu
 txt_7_8_rel: Extracció interactiva
 txt_7_8_prioritynormal: Normal
 txt_7_8_priorityrealtime: En temps real
 txt_7_8_requirerestart: [requereix reiniciar el PeaZip]
 txt_7_8_tpriority: Prioritat de tasques
 txt_7_8_update: Actualitza
-txt_7_7_noneall: None: disable preview, edit, drag&drop and interactive extraction
-txt_7_7_nonetemp: None, user's temp if necessary
+txt_7_7_noneall: Cap: desactiva la previsualització, l'edició, la funcionalitat d'"arrossega i deixa anar" i l'extracció interactiva
+txt_7_7_nonetemp: Cap, el directori temporal de l'usuari si és necessari
 txt_7_7_outtemp: Output, preview in user's temp
-txt_7_7_sys7zreq: Requires p7zip-full or equivalent to be installed
-txt_7_7_tw: Temporary work folder for archive creation, editing, preview and drag&drop extraction
-txt_7_7_sys7z: Use system 7z in Linux
-txt_7_6_zipenc: 7z/p7zip ZIP filenames encoding
+txt_7_7_sys7zreq: Requereix tenir instal·lat el p7zip-full o equivalent
+txt_7_7_tw: Carpeta de treball temporal per crear arxius, editar-los, previsualitzar-los i extreure'ls amb la funcionalitat "arrossega i deixa anar"
+txt_7_7_sys7z: Utilitza el 7z del sistema del Linux
+txt_7_6_zipenc: Codificació de noms de fitxer ZIP 7z / p7zip
 txt_7_6_color: Color
-txt_7_6_custenc: Custom code page
+txt_7_6_custenc: Pàgina de codis personalitzats
 txt_7_6_dark: Fosc
-txt_7_6_tno: Do not sync archive tree
-txt_7_6_forcelocalenc: Force local
-txt_7_6_forceutf8enc: Force UTF-8
-txt_7_6_cpnote: If the chosen custom code page is unsupported, tasks will always end in error (most likely memory allocation error). In case that happens, change code page or reset the application.
-txt_7_6_defaultenc: Local, UTF-8 for extra symbols
-txt_7_6_dim: Low light
+txt_7_6_tno: No sincronitzis l'arbre de l'arxiu
+txt_7_6_forcelocalenc: Força'l local
+txt_7_6_forceutf8enc: Força'l UTF-8
+txt_7_6_cpnote: Si la pàgina de codis personalitzats escollida no és compatible, les tasques acabaran sempre amb un error (probablement, un error d'assignació de memòria). En cas que això passi, canvieu la pàgina de codis o restabliu l'aplicació.
+txt_7_6_defaultenc: Local, UTF-8 per a símbols addicionals
+txt_7_6_dim: Clar
 txt_7_6_setcurdef: Estableix la ubicació actual com a ubicació d'extracció per defecte
 txt_7_6_setdef: Estableix una ubicació d'extracció per defecte
-txt_7_6_tadvanced: Sync archive tree, keep visited nodes
-txt_7_6_tsimple: Sync archive tree, simple
-txt_7_6_tacolor: Text accent
+txt_7_6_tadvanced: Sincronitza l'arbre de l'arxiu, manté els elements visitats
+txt_7_6_tsimple: Sincronitza l'arbre de l'arxiu, simple
+txt_7_6_tacolor: Accent de text
 txt_7_5_always: Sempre
-txt_7_5_ask: Ask
-txt_7_5_autoclosesingle: Auto close after extraction if no browsing actions took place
-txt_7_5_cutlen: Retalla el nom en una longitud determinada
-txt_7_5_cutlenw: Cut name at specified length (4..255) naming conflicts can be fixed manually later
-txt_7_5_dragnone: Do not lock target
-txt_7_5_specialbrowse: Do you want to extract everything in order to provide the file with the extra data it may need?
-txt_7_5_ee: Extract everything for special file types
-txt_7_5_draghide: Hide drop target
-txt_7_5_draglh: Lock and hide target
-txt_7_5_draglock: Lock drop target
+txt_7_5_ask: Pregunta
+txt_7_5_autoclosesingle: Tanca automàticament després de l'extracció si no es realitza cap acció de navegació
+txt_7_5_cutlen: Retalla el nom a una longitud determinada
+txt_7_5_cutlenw: Retalla el nom a una longitud determinada (4..255) els conflictes de noms es poden corregir manualment més tard
+txt_7_5_dragnone: No bloquegis el destí
+txt_7_5_specialbrowse: Vols extreure-ho tot per proporcionar al fitxer les dades addicionals que pugui necessitar?
+txt_7_5_ee: Extraieu-ho tot per a tipus de fitxers especials
+txt_7_5_draghide: Amaga el destí
+txt_7_5_draglh: Bloqueja i amaga el destí
+txt_7_5_draglock: Bloqueja el destí
 txt_7_5_never: Mai
-txt_7_5_repnascii: Replace/remove non-ASCII characters
+txt_7_5_repnascii: Substitueix / elimina caràcters que no siguin ASCII
 txt_7_4_comment: Comenta
 txt_7_4_7zfbrotlicomp: Fastest compression, 7Z Brotli
 txt_7_4_7zfzstandardcomp: Fastest compression, 7Z Zstandard
@@ -181,7 +181,7 @@ txt_6_1_ec: Expand / collapse archive tree
 txt_6_0_msq: Sort by file type for solid compression
 txt_5_9_lff: Analyze files and folders
 txt_5_9_pff: Analyze, show files header/EOF
-txt_5_9_start: Start from
+txt_5_9_start: Comença a
 txt_5_8_l0: Allow any supported component/format
 txt_5_8_l1: Allow only Free Software components
 txt_5_8_l2: Allow only open archive formats
@@ -242,7 +242,7 @@ txt_5_4_da: Date added
 txt_5_4_deletearchives: Delete archives after extraction
 txt_5_4_deletefiles: Delete files after archiving
 txt_5_4_deleteoriginal: Deletion procedure, as set in main screen, will be appended to the script.
-txt_5_4_lv: Last visited
+txt_5_4_lv: Últim lloc visitat
 txt_5_4_deletearchivesconfirm: Confirm deletion of original archives?
 txt_5_4_deletefilesconfirm: Confirm deletion of original files?
 txt_5_4_used: Utilitzat
@@ -346,7 +346,7 @@ txt_4_8_rr: Gira a la dreta
 txt_4_8_stop: Atura
 txt_4_8_t: Transforma
 txt_4_8_w: Amplada
-txt_4_7_pk: Genera una contrasenya / fitxer-clau aleatori/a
+txt_4_7_pk: Genera una contrasenya / fitxer de xifratge aleatori/a
 txt_4_7_spchar: Limita els caràcters a lletres i números
 txt_4_7_recycleask: Vols moure els fitxers seleccionats a la paperera de reciclatge?
 txt_4_7_recycle: Desplaça a la paperera de reciclatge
@@ -375,7 +375,7 @@ txt_4_4_confremove: Vols eliminar la configuració del PeaZip?
 txt_4_3_pwmanhint: Double click to edit items in password list, rightclick for options, Ctrl+C to copy passwords
 txt_4_3_exppl: Exporta la llista de contrasenyes
 txt_4_3_expple: Encrypted (backup Password Manager)
-txt_4_3_keeppw: Recorda la contrasenya/fitxer-clau durant la sessió actual
+txt_4_3_keeppw: Recorda la contrasenya/fitxer de xifratge durant la sessió actual
 txt_4_3_pwmanpwhint: Setting a password/keyfile (optional) to encrypt password list is recommended, in this way authentication will be required to access to the Password Manager. Password/keyfile can be changed at any time from this form.
 txt_4_3_pwmanmaster: Estableix/canvia la contrasenya global
 txt_4_3_pwmanlist: Llista de contrasenyes
@@ -445,7 +445,7 @@ txt_2_9_copyhere: Copia aquí
 txt_2_9_noscan: Don't scan files being added to layout
 txt_2_9_extconsole: Extraction console is available only while browsing archives
 txt_2_9_thl: Highlight buttons
-txt_2_9_home: Home
+txt_2_9_home: Directori de l'usuari
 txt_2_9_lt: Gran
 txt_2_9_mt: Mitjà
 txt_2_9_movehere: Mou-lo aquí
@@ -491,7 +491,7 @@ txt_2_7_separate: Add each object to a separate archive
 txt_2_7_pwsupported: archiving with password
 txt_2_7_cancel: Cancel·la
 txt_2_7_encfn: Encripta també els noms dels fitxers (si el format ho suporta)
-txt_2_7_setpw: Introdueix una contrasenya / fitxer-clau
+txt_2_7_setpw: Introdueix una contrasenya / fitxer de xifratge
 txt_2_7_ext: Extraient:
 txt_2_7_extfrom: Extraient de l'arxiu:
 txt_2_7_es: Extract supported non-archive file types, i.e. executables, MS Office and OOo files
@@ -558,7 +558,7 @@ txt_2_4_wenc: Encyclopedia
 txt_2_4_extractfrom: Extreu desde
 txt_2_4_hexp: Previsualització hex
 txt_2_4_operation: Operació
-txt_2_4_path: la ubicació no es pot escriure (p.ex. només lectura). Vols seleccionar una altra ubicació d'extracció escrivible?
+txt_2_4_path: la ubicació no es pot escriure (p. ex. només lectura). Vols seleccionar una altra ubicació d'extracció escrivible?
 txt_2_4_removefromclipboard: Elimina del porta-retalls
 txt_2_4_stdclip: Standard: keep a single selection in clipboard, clear cut operations on paste
 txt_2_4_totalmem: memòria total
@@ -570,7 +570,7 @@ txt_2_4_wdict: Wiktionary
 txt_2_3_pw_errorchar: quote character is not recommended to be used in passwords (for PeaZip and scripts). If you need to create or extract an archive with this password you can dismiss the message and you will be asked to enter the password interactively in console.
 txt_2_3_envstr: Display environment variables
 txt_2_3_never_pw: Don't ask for password
-txt_2_3_home: User's home
+txt_2_3_home: Directori de l'usuari
 txt_2_3_on_pw: On extract/list/test operations from system's menus:
 txt_2_3_test_pw100: Test for encryption <100MB archives
 txt_2_3_test_pw: Test for encryption (may be slow)
@@ -696,13 +696,13 @@ txt_copyto: Copia a...
 txt_create: Create
 txt_create_archive: Create new archive
 txt_title_create: Create archive, compress, encrypt, split...
-txt_create_keyfile: Crea un fitxer-clau
+txt_create_keyfile: Crea un fitxer de xifratge
 txt_create_folder: Create new folder
 txt_create_theme: Create Theme from current settings
 txt_rr: Create recovery records
 txt_create_sfx: Create self-extracting archive
 txt_cr_current: Current path or filter compression ratio
-txt_custom: Custom
+txt_custom: Personalitzat
 txt_type_description_custom: Custom (advanced users): enter executable name and parameters
 txt_customapp: Aplicació personalitzada
 txt_custom_parameters: Paràmetres personalitzats
@@ -845,7 +845,7 @@ txt_job_definition_saved: Task definition successfully saved in
 txt_job_success: Task successfully completed!
 txt_join: Join
 txt_joinfiles: Join files
-txt_keyfile: Fitxer-clau
+txt_keyfile: Fitxer de xifratge
 txt_keyfile_not_found: Keyfile cannot be found or read. Please chose a different Keyfile.
 txt_keyfile_notcreated: KeyFile not created
 txt_larger: Larger than selected object
@@ -1046,7 +1046,7 @@ txt_taskman: Task Manager
 txt_caption_test: Verifica
 txt_testall: Verifica-ho tot
 txt_testdisp: Verifica els objectes mostrats
-txt_testpw: Verifica la contrasenya / fitxer-clau
+txt_testpw: Verifica la contrasenya / fitxer de xifratge
 txt_testsel: Verifica els objectes seleccionats
 txt_col_hint: The color should be chosen in order to integrate well with icon colors and to other GUI's elements
 txt_bookmarks_hint: The complete and editable list of bookmarks is available in the file browser interface, clicking on the "More controls" icon and on "Toggle history/bookmarks"
@@ -1135,10 +1135,10 @@ txt_3_0_details: For more details, "Report" contains the task's log, and "Consol
 txt_3_0_hints: Hints about the error
 txt_3_0_arc: Some input files cannot be read (may be locked, not accessible or corrupted, volumes in multipart archive may be missing)
 txt_3_0_ext: The archive may require a different password for the current operation
-txt_2_8_oop: Open output path when task completes
-txt_2_7_validatefn: Operation stopped, invalid file name detected:
-txt_2_7_validatecl: Operation stopped, potentially dangerous command detected (i.e. command concatenation not allowed within the program):
-txt_2_6_open: Open archive
+txt_2_8_oop: Obre l'ubicació de sortida quan finalitzi la tasca
+txt_2_7_validatefn: S'ha aturat l’operació, s'ha detectat un nom de fitxer invàlid:
+txt_2_7_validatecl: S'ha aturat l’operació, s'ha detectat una comanda potencialment perillosa (p. ex. comandes concatenades no permeses al programa):
+txt_2_6_open: Obre un arxiu
 txt_2_5_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
 txt_2_3_pw_errorchar_gwrap: quote character cannot be used by PeaLauncher in passwords under current system, please change password or chose Console mode in Backend binaries user interface in Options > Settings
 txt_2_3_renameexisting: Reanomena automàticament els fitxers existents
@@ -1146,8 +1146,8 @@ txt_2_3_renameextracted: Reanomena automàticament els fitxers extrets
 txt_2_3_cancel: Cancel·la
 txt_2_3_encryption: Encriptació
 txt_2_3_extinnew: Extreu-ho en una nova carpeta
-txt_2_3_keyfile: Fitxer-clau
-txt_2_3_kf_not_found_gwrap: Keyfile cannot be found or read. Please chose a different Keyfile.
+txt_2_3_keyfile: Fitxer de xifratge
+txt_2_3_kf_not_found_gwrap: No s'ha trobat o no s'ha pogut llegir el fitxer de xifratge. Si us plau, escull un fitxer de xifratge diferent.
 txt_2_3_moreoptions: Més opcions...
 txt_2_3_nopaths: Sense camins
 txt_2_3_options: Opcions
@@ -1156,51 +1156,51 @@ txt_2_3_pw: Contrasenya
 txt_2_3_skipexisting: Salta els fitxers existents
 txt_job_unknown: : S'ha trobat un error desconegut
 txt_stdjob: [l'animació s'aturarà quan es completi la tasca]
-txt_benchmarkjob: [system will respond slowly while running the benchmark (some minutes)]
-txt_defragjob: [will not respond while defragmenting, you can let it run in background]
-txt_consolejob: [task's feedback and detailed progress available in console window]
-txt_job1: 1: Avís: s'han produït errors lleus; p.ex. no s'han trobat alguns fitxers o estaven bloquejats
+txt_benchmarkjob: [el sistema respondrà lentament mentre s'executi la prova de rendiment del sistema (pot tardar alguns minuts)]
+txt_defragjob: [no respondrà mentre transcorri la desfragmentació, pots executarlo en segon pla]
+txt_consolejob: [pots consultar l'evolució de la tasca a la finestra de la consola]
+txt_job1: 1: Avís: s'han produït errors lleus; p. ex. no s'han trobat alguns fitxers o estaven bloquejats
 txt_job127: 127: No s'ha pogut executar la operació sol·licitada
 txt_job2: 2: Error fatal
-txt_job255: 255: Task halted by the user
+txt_job255: 255: Tasca interrompuda per l'usuari
 txt_job7: 7: Error: línia de comandes incorrecta
 txt_job8: 8: Error: no hi ha prou memòria per a la operació sol·licitada
 txt_autoclose: Tanca la finestra quan finalitzi la tasca
 txt_crscale: Ràtio de compressió (com més baixa, millor):
 txt_console: Consola
-txt_benchscale: Core 2 Duo 6600 rating, equivalent MHz speed.
+txt_benchscale: Evaluació Core 2 Duo 6600, equivalent a la velocitat de MHz.
 txt_create: Crea
 txt_done: Fet:
-txt_nocl: Línia de comandes buida
+txt_nocl: Buida la línia de comandes
 txt_error: Error:
 txt_explore: Explora
 txt_extto: Extreu a
-txt_halt: Halt system when task completes
-txt_halted: Halted:
+txt_halt: Apaga l'ordinador en finalitzar la tasca
+txt_halted: Interromput:
 txt_hardware: hardware
 txt_high: prioritat alta
-txt_idle: idle priority
+txt_idle: prioritat quan estigui inactiu
 txt_input: Entrada:
 txt_jpaused: Tasca pausada
 txt_jresumed: Tasca continuada
 txt_job_started: Tasca iniciada
 txt_jobstatus: Estat de la tasca:
-txt_jstopped: Task halted by the user
-txt_jobstopped: Task halted by the user; you can inspect the partial outcome clicking output path link.
+txt_jstopped: Tasca interrompuda per l'usuari
+txt_jobstopped: L'usuari ha interromput la tasca; pots revisar el resultat parcial fent clic a l'enllaç del directori de sortida.
 txt_job_success: Tasca completada satisfactòriament
-txt_lt: List/test
+txt_lt: Allista/verifica/repara un fitxer
 txt_normal: prioritat normal
-txt_ok: OK
+txt_ok: D'acord
 txt_output: Sortida:
 txt_pause: Pausa
 txt_paused: Pausada,
-txt_p_high: Priority set to high
-txt_p_idle: Priority set to idle
-txt_p_normal: Priority set to normal
-txt_p_realtime: Priority set to real time
+txt_p_high: Estableix la prioritat alta
+txt_p_idle: Estableix la prioritat quan estigui inactiu
+txt_p_normal: Estableix la prioritat normal
+txt_p_realtime: Estableix la prioritat en temps real
 txt_rating: Valoració:
 txt_rt: prioritat en temps real
-txt_report: Report
+txt_report: Informe
 txt_resume: Continua
 txt_priority: Fes clic aquí per establir la prioritat de la tasca
 txt_running: En curs,
@@ -1212,7 +1212,7 @@ txt_software: programa
 txt_speedscale: Velocitat, escala logarítmica (com més alta, millor):
 txt_status: Estat
 txt_stop: Atura
-txt_bench: System benchmark
+txt_bench: Prova de rendiment del sistema
 txt_threads: Fils:
 txt_time: Temps:
 

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -411,7 +411,7 @@ txt_3_5_managecustomthemes: Administrador de temes
 txt_3_4_nopaths: Sense rutes
 txt_3_4_smallicons: Icones
 txt_3_3_skipunits: (Windows) Recopila informació dels volums d'unitats en xarxa, inici més lent
-txt_3_3_stralt: Comanda alternativa, quan no s'especifiqui cap paràmetre
+txt_3_3_stralt: Ordre alternativa, quan no s'especifiqui cap paràmetre
 txt_3_3_apps: Aplicacions
 txt_3_3_multi: Selecció múltiple
 txt_3_3_runexp: Obre un programa, fitxers, carpeta o lloc web
@@ -475,59 +475,59 @@ txt_2_8_convertexisting: Converteix els fitxers existents
 txt_2_8_convertdelete: Vols suprimir fitxers i carpetes creats temporalment per a la conversió?
 txt_2_8_details: Detalls
 txt_2_8_parallel: Executa les tasques en paral·lel quan sigui possible
-txt_2_8_convertnote: In any case original archives were not modified, to let the user in control about keeping or removing them
-txt_2_8_custom: is not directly supported by PeaZip, but in extraction stage you can set PeaZip to handle custom file types in "Advanced" tab. Proceed opening this file?
-txt_2_8_unitrecommend: It is recommended either to extract (rightclick > extract selected) or to open filesystems from computer's root (system tools > Open unit as archive)
-txt_2_8_viewasarchive: Open unit as archive
+txt_2_8_convertnote: En qualsevol cas, els arxius originals no s'han modificat, per tal de permetre a l'usuari controlar la seva conservació o eliminació
+txt_2_8_custom: no es suporta directament amb el PeaZip, però a la fase d'extracció pots configurar PeaZip per gestionar tipus de fitxers personalitzats a la pestanya "Avançat". Vols continuar obrint aquest fitxer?
+txt_2_8_unitrecommend: Es recomana extreure (Botó dret > Extreu els objectes seleccionats) o obrir sistemes de fitxers des de l'arrel de l'ordinador (Eines del sistema > Obre la unitat com a arxiu)
+txt_2_8_viewasarchive: Obre la unitat com a arxiu
 txt_2_8_nounit: No s'ha seleccionat cap unitat
-txt_2_8_rowselect: Row select
+txt_2_8_rowselect: Selecció de fila
 txt_2_8_statusbar: Barra d'estat
-txt_2_8_typeunit: Type logical or physical unit name
+txt_2_8_typeunit: Introdueix el nom de la unitat lògica o física
 txt_2_8_usedefaultoutpath: Utilitza sempre la ubicació d'extracció per defecte
 txt_2_7_experimental: (experimental, vegeu la documentation)
 txt_2_7_optional: (opcional)
-txt_2_7_list_tryflatorpw: , possible solutions: try flat view (F6), provide password (F9), get a fresh copy of the archive
-txt_2_7_separate: Add each object to a separate archive
-txt_2_7_pwsupported: archiving with password
+txt_2_7_list_tryflatorpw: , possibles solucions: prova la visualització plana (F6), proporciona una contrasenya (F9) o prova-ho amb una nova còpia de l'arxiu
+txt_2_7_separate: Afegeix cada objecte a un arxiu separat
+txt_2_7_pwsupported: arxivant amb contrasenya
 txt_2_7_cancel: Cancel·la
 txt_2_7_encfn: Encripta també els noms dels fitxers (si el format ho suporta)
 txt_2_7_setpw: Introdueix una contrasenya / fitxer de xifratge
 txt_2_7_ext: Extraient:
 txt_2_7_extfrom: Extraient de l'arxiu:
-txt_2_7_es: Extract supported non-archive file types, i.e. executables, MS Office and OOo files
-txt_2_7_eu: Extract unsupported file types, specifying custom extraction utility
+txt_2_7_es: Extreu els tipus de fitxers compatibles que no són comprimits, p. ex. executables, MS Office i fitxers OOo
+txt_2_7_eu: Extreu tipus de fitxers no suportats, especificant una utilitat d'extracció personalitzada
 txt_2_7_clipboard: Porta-retalls
-txt_2_7_goarclayout: Go to archiving layout
-txt_2_7_goextlayout: Go to extraction layout
+txt_2_7_goarclayout: Ves a la maquetació de compressió
+txt_2_7_goextlayout: Ves a la maquetació d'extracció
 txt_2_7_ok: OK
-txt_2_7_drag_archive: open file as new archive? ("No" to add file to current archiving layout)
+txt_2_7_drag_archive: vols obrir el fitxer com a nou arxiu? (clica "No" per afegir el fitxer a la finestra actual d'arxivament)
 txt_2_7_oop: Obra la ubicació d'extracció quan finalitzi el procés
-txt_2_7_validatefn: Operation stopped, invalid file name detected:
-txt_2_7_validatecl: Operation stopped, potentially dangerous command detected (i.e. command concatenation not allowed within the program):
-txt_2_7_output: Output
-txt_2_7_pwnotset: Password is not set 
-txt_2_7_pwarcset: Password is set
-txt_2_7_pwextset: Password is set, it is possible to extract/list/test encrypted archives
-txt_2_7_archivehint: Drag here files and folders to archive, or right-click for more options
-txt_2_7_exthint: Drag here archives to extract, or right-click for more options
-txt_2_7_setadvf: Set advanced filters
-txt_2_7_selpath: Selected item's path
-txt_2_7_separateerror: Sorry, cannot import task definition's command line while using "Add each object to a separate archive" switch, since the task is performed as multiple distinct commands
-txt_2_7_noinput: The layout is empty: please use Add file(s) or Load Layout to populate the list of archives to be extracted
-txt_2_7_dirsize: The size of the content of folders is not checked for calculating the total size
-txt_2_7_un7z_browse_flat: try flat view (F6)
-txt_2_7_updating: Updating existing archive
+txt_2_7_validatefn: L'operació s'ha aturat, s'ha detectat un nom de fitxer no vàlid:
+txt_2_7_validatecl:  L'operació s'ha aturat, s'ha detectat una ordre potencialment perillosa (p. ex. concatenació d'ordres prohibides dins del programa):
+txt_2_7_output: Sortida
+txt_2_7_pwnotset: Contrasenya no definida
+txt_2_7_pwarcset: Contrasenya definida
+txt_2_7_pwextset: Contrasenya definida, és possible extreure, llistar i verificar arxius xifrats
+txt_2_7_archivehint: Arrossega fitxers i carpetes aquí per arxivar-los, o fes clic amb el botó dret per obtenir més opcions
+txt_2_7_exthint: Arrossega arxius comprimits aquí per extreure'ls, o fes clic amb el botó dret per obtenir més opcions
+txt_2_7_setadvf: Estableix filtres avançats
+txt_2_7_selpath: Camí de l'element seleccionat
+txt_2_7_separateerror: No es poden importar les ordres de la tasca mentre la opció "Afegeix cada objecte a un arxiu separat" està activada, ja que la tasca s'executa com a múltiples ordres diferents
+txt_2_7_noinput: La maquetació és buida: utilitza Afegeix fitxers o Carrega disseny per omplir la llista d’arxius que s’extreuran
+txt_2_7_dirsize: No es comprova la mida del contingut de les carpetes per calcular la mida total
+txt_2_7_un7z_browse_flat: prova la vista plana (F6)
+txt_2_7_updating: S'està actualitzant l'arxiu existent
 txt_2_6_folders: (carpetes)
 txt_2_6_advanced: Avançat
-txt_2_6_plalways: Always keep open to inspect task's report
-txt_2_6_plsmart: Keep open only if needed (error, list or test reports)
+txt_2_6_plalways: Mantén-lo sempre obert per inspeccionar l'informe de la tasca
+txt_2_6_plsmart: Mantén-lo obert només si cal (informes d'errors, llista o proves)
 txt_2_5_sessionio: (aquesta sessió)
-txt_2_5_advanced: Advanced edit: place spaces between parameter strings and filename if needed
-txt_2_5_basic: Basic edit: application and parameters before input name
-txt_2_5_cannotrun: Cannot run
-txt_2_5_custeditors: Custom editors, players, antivirus scanners etc... (override system's file associations)
-txt_2_5_delete: Delete
-txt_2_5_delete_fromarchive: Delete from archive
+txt_2_5_advanced: Edició avançada: col·loqueu espais entre les cadenes de paràmetres i el nom del fitxer si cal
+txt_2_5_basic: Edició bàsica: aplicació i paràmetres abans de la introducció del nom
+txt_2_5_cannotrun: No es pot executar
+txt_2_5_custeditors: Editors personalitzats, reproductors, antivirus, etc ... (sobreescriu les associacions de fitxers del sistema)
+txt_2_5_delete: Suprimeix
+txt_2_5_delete_fromarchive: Suprimeix de l'arxiu
 txt_2_5_langflag: Display archived object's name as UTF-8 text; uncheck to replace extended characters with "?"
 txt_2_5_encpj: Encode task definition as UTF-8 text
 txt_2_5_execommand: Executable or command

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -38,7 +38,7 @@ txt_8_0_forcetyping: Força l’escriptura de contrasenyes de manera interactiva
 txt_8_0_setpwopt: Configura les opcions de contrasenya i dels fitxers de xifratge
 txt_8_0_forcetypinghelp: Will run backend binaries in console, cannot browse archives with encrypted filenames. Allows to create scripts that will not run unattended but rather ask user interactively for password.
 txt_7_9_spacing: Espaiat
-txt_7_9_zooming: Zooming
+txt_7_9_zooming: Proporció d'ampliació
 txt_7_8_changelocalization: Canvia l'idioma del PeaZip
 txt_7_8_custext: Extensió personalitzada
 txt_7_8_destexistfile: La destinació ja conté fitxers processats. Vols substituir-los?
@@ -151,7 +151,7 @@ txt_6_5_seqerr: Error(s) detectats, no s'eliminaran els fitxers originals
 txt_6_5_sni: Inclou la informació de seguretat NT
 txt_6_5_sns: Inclou NTFS Alternate Data Stream
 txt_6_5_privacy: Privacitat
-txt_6_5_showvolatile: Mostra quines opcions són volàtils / dependen del context
+txt_6_5_showvolatile: Mostra quines opcions són volàtils o dependents del context
 txt_6_5_force: Intenta obrir arxius que contenen errors
 txt_6_5_warning: Avís
 txt_6_5_yes: Sí
@@ -185,82 +185,82 @@ txt_5_9_start: Comença a
 txt_5_8_l0: Permet qualsevol component o format admès
 txt_5_8_l1: Permet només components de programari lliure
 txt_5_8_l2: Permet només formats d'arxiu oberts
-txt_5_8_ascii: ASCII safe, scripts are safe on legacy environments
-txt_5_8_cp: Code Page safe, scripts may trigger problems on legacy environments with different Code Pages
-txt_5_8_fs: Free Software compliance
-txt_5_8_utf: Scripts need full UTF-8 / Unicode environment
-txt_5_8_fsr: This format is not supported due Free Software compliance restrictions (Options > Advanced)
+txt_5_8_ascii: ASCII segur, els scripts són compatibles amb entorns antics
+txt_5_8_cp: Pàgina de codi segura, els scripts poden provocar problemes en entorns antics amb pàgines de codi diferents
+txt_5_8_fs: Compliment de la política del programari lliure
+txt_5_8_utf: Els scripts necessiten un entorn UTF-8/Unicode complet
+txt_5_8_fsr: No es suporta aquest format a causa de la restricció de compliment de la política del programari lliure (Opcions > Avançat)
 txt_5_7_pinstalled: INSTAL·LAT
 txt_5_7_pmissing: ABSENT
-txt_5_7_plugin: Plugin missing, can be installed from Help > Check for plugin and addon
+txt_5_7_plugin: Falta un complement, el pots instal·lar desde Ajuda > Cerca connectors i complements
 txt_5_6_basic: Basic
-txt_5_6_exarc: Extract archive
+txt_5_6_exarc: Extreu l'arxiu
 txt_5_6_tab: Obre en una pestanya nova
-txt_5_6_rc: Right click for options
-txt_5_6_layouts: Saved layouts
-txt_5_6_upexisting: Update existing archive
-txt_5_6_verbose: Verbose
+txt_5_6_rc: Botó de la dreta per veure les opcions
+txt_5_6_layouts: Maquetacions desades
+txt_5_6_upexisting: Actualitza l'arxiu existent
+txt_5_6_verbose: Detallat
 txt_5_5_case: (sensible a les majúscules)
-txt_5_5_add: Add string at specified position
+txt_5_5_add: Afegeix una cadena alfanumèrica a la posició especificada
 txt_5_5_addsel: Afegeix a la selecció
 txt_5_5_ext: Canvia les extensions dels fitxers
-txt_5_5_plugin: Check for plugin and addon
-txt_5_5_copypath: Copy path
-txt_5_5_delete: Delete characters at specified position
-txt_5_5_halt: Halt system when task completes
-txt_5_5_positionw: Hint: 1 add before first char, 2 second, etc... "z" for end of file name
-txt_5_5_positionwd: Hint: 1 delete from first char included, 2 second, ... "z" for end of file name
-txt_5_5_replaceneww: Hint: provide an empty new string to simply remove the old string
-txt_5_5_lower: lowercase
-txt_5_5_replaceoldw: Modify all occurrences of this string or character in the file name
+txt_5_5_plugin: Cerca connectors i complements
+txt_5_5_copypath: Copia el camí
+txt_5_5_delete: Elimina caràcters a la posició especificada
+txt_5_5_halt: Apaga el sistema quan es completi la tasca
+txt_5_5_positionw: Suggeriment: 1 per afegir abans del primer caràcter, 2 pel segon, etc... "z" pel final del nom del fitxer
+txt_5_5_positionwd: Suggeriment: 1 eliminar des del primer caràcter inclòs, 2 des del segon... "z" pel final del nom del fitxer
+txt_5_5_replaceneww: Suggeriment: proporciona una nova cadena alfanumèrica buida per eliminar l'anterior
+txt_5_5_lower: minúscules
+txt_5_5_replaceoldw: Modifica totes les occurències d'aquesta cadena alfanumèrica o caràcter al nom del fitxer
 txt_5_5_newext: Nova extensió
-txt_5_5_new: New string
-txt_5_5_n: Number of characters to delete
-txt_5_5_old: Old string
-txt_5_5_position: Position (number or "z" for end)
+txt_5_5_new: Nova cadena alfanumèrica
+txt_5_5_n: Número de caràcters a eliminar
+txt_5_5_old: Cadena alfanumèrica antiga
+txt_5_5_position: Posició (número, o bé, "z" per indicar l'última posició)
 txt_5_5_intdir: Nova carpeta intel·ligent
-txt_5_5_replacestr: Replace/remove string
-txt_5_5_datesameday: Same day of selected object
-txt_5_5_datesamehour: Same hour of selected object
-txt_5_5_datesamemonth: Same month of selected object
-txt_5_5_datesameweek: Same week of selected object
-txt_5_5_datesameyear: Same year of selected object
+txt_5_5_replacestr: Reemplaça/elimina la cadena alfanumèrica
+txt_5_5_datesameday: El mateix dia que l'objecte seleccionat
+txt_5_5_datesamehour: La mateixa hora que l'objecte seleccionat
+txt_5_5_datesamemonth: El mateix mes que l'objecte seleccionat
+txt_5_5_datesameweek: La mateixa setmana que l'objecte seleccionat
+txt_5_5_datesameyear: El mateix any que l'objecte seleccionat
 txt_5_5_scan: Escaneja
-txt_5_5_select: Select
-txt_5_5_similar: Similar to selected object
-txt_5_5_starting: Starting with same character
-txt_5_5_string: String to add
-txt_5_5_subtractsel: Subtract from current selection
+txt_5_5_select: Selecciona
+txt_5_5_similar: Semblant a l'objecte seleccionat
+txt_5_5_starting: Que comenci amb el mateix caràcter
+txt_5_5_string: Cadena alfanumèrica a afegir
+txt_5_5_subtractsel: Desmarca de la selecció actual
 txt_5_5_datehour: Aquesta hora
 txt_5_5_datemonth: Aquest mes
 txt_5_5_dateweek: Aquesta setmana
 txt_5_5_dateyear: Aquest any
 txt_5_5_dateday: Avui
-txt_5_5_upper: UPPERCASE
-txt_5_5_extw: Warning: changing file extension the file may become unusable
-txt_5_4_da: Date added
-txt_5_4_deletearchives: Delete archives after extraction
-txt_5_4_deletefiles: Delete files after archiving
-txt_5_4_deleteoriginal: Deletion procedure, as set in main screen, will be appended to the script.
+txt_5_5_upper: MAJÚSCULES
+txt_5_5_extw: Avís: si es modifica l'extensió, pot ser que el fitxer quedi inservible
+txt_5_4_da: Data afegit
+txt_5_4_deletearchives: Elimina els arxius després de l'extracció
+txt_5_4_deletefiles: Elimina els fitxers després de la compressió
+txt_5_4_deleteoriginal: El procés d'eliminació, tal i com s'ha establert a la finestra principal, s'afegirà al script.
 txt_5_4_lv: Últim lloc visitat
-txt_5_4_deletearchivesconfirm: Confirm deletion of original archives?
-txt_5_4_deletefilesconfirm: Confirm deletion of original files?
+txt_5_4_deletearchivesconfirm: Confirmes l'eliminació dels arxius originals?
+txt_5_4_deletefilesconfirm: Confirmes l'eliminació dels fitxers originals?
 txt_5_4_used: Utilitzat
-txt_5_3_profilebest: Extreme compression, 7Z ultra
-txt_5_3_profileadvanced: High compression, 7Z
-txt_5_3_profilenormal: Medium compression, ZIP (compatible with most extractors)
-txt_5_3_profileveryfast: Fast compression, ZIP fast (compatible with most extractors)
-txt_5_3_profilepassword: Protect with password, 7Z format
+txt_5_3_profilebest: Compressió extrema, 7Z ultra
+txt_5_3_profileadvanced: Compressió alta, 7Z
+txt_5_3_profilenormal: Compressió mitjana, ZIP (compatible amb la majoria d'extractors)
+txt_5_3_profileveryfast: Compressió ràpida, ZIP ràpid (compatible amb la majoria d'extractors)
+txt_5_3_profilepassword: Protegeix amb contrasenya, format 7Z
 txt_5_3_profile10mb: Manté el resultat per sota dels 25 MB, per les limitacions d'enviament
-txt_5_3_profilesfx: Auto extracting, recipient will not need an extraction software
+txt_5_3_profilesfx: Auto-extraïble, el destinatari no necessitarà cap programa d'extracció
 txt_5_3_cml: Idioma del menú contextual del sistema
-txt_5_3_cmlmessage: Double click on desired context menu language and confirm registry merging. This setting needs to be re-applied when the application is installed/updated or after System integration wizard is used.
-txt_5_3_exc: Exclusion filters prevail on inclusion filters
+txt_5_3_cmlmessage: Fes doble clic a l'idioma del menú contextual desitjat i confirma l'aplicació al registre. Aquesta configuració necessita tornar-se a aplicar quan s'instal·la o s'actualitza l'aplicació, o després d'utilitzar l'assistent d'integració amb el sistema.
+txt_5_3_exc: Els filtres d'exclusió prevalen sobre els filtres d'inclusió
 txt_5_3_ia: Inclou també
 txt_5_3_io: Inclou només
-txt_5_3_rec: Recurse subdirs
-txt_5_3_resetsi: Re-configure system integration (context menu, SendTo, file associations)?
-txt_5_2_oadd: Archive to original path
+txt_5_3_rec: Subdirectoris recursius
+txt_5_3_resetsi: Vols reconfigurar la integració amb el sistema (menú contextual, Enviar a, associacions de fitxers)?
+txt_5_2_oadd: Comprimeix a la ubicació original
 txt_5_2_zerodelete: Vols eliminar i reemplaçar els fitxers seleccionats amb 0? La operació no es pot desfer i els fitxers no es podran recuperar
 txt_5_2_zfree: Vols reemplaçar l'espai lliure d'aquesta unitat amb 0?
 txt_5_2_sdfree: Vols esborrar l'espai lliure d'aquesta unitat de forma segura?
@@ -279,9 +279,9 @@ txt_5_1_every: Cada
 txt_5_1_w6: Divendres
 txt_5_1_hourly: Cada hora
 txt_5_1_hours: Hores
-txt_5_1_last: Last
-txt_5_1_schedmanage: Task Scheduler, manage tasks saved in PeaZip branch
-txt_5_1_scriptmanage: Manage saved scheduled scripts
+txt_5_1_last: Última
+txt_5_1_schedmanage: Programador de tasques, gestió de tasques desades delete PeaZip
+txt_5_1_scriptmanage: Gestió de tasques programades
 txt_5_1_w2: Dilluns
 txt_5_1_monthly: Mensualment
 txt_5_1_months: Mesos
@@ -289,10 +289,10 @@ txt_5_1_onlogin: En iniciar la sessió de l'usuari
 txt_5_1_onstart: A l'engegada
 txt_5_1_once: Una vegada
 txt_5_1_w7: Dissabte
-txt_5_1_schedule: Schedule
-txt_5_1_schedexplain: Creates a plain text script from GUI task definition and schedule it. Scheduled tasks' scripts are saved in "Scheduled scripts" folder. To edit or delete scheduled tasks you can use system's Task Scheduler, all scheduled tasks created by PeaZip are collected in "PeaZip" branch of the tasks library.
-txt_5_1_schedok: Schedule created successfully
-txt_5_1_schedscripts: Saved scheduled scripts
+txt_5_1_schedule: Programa
+txt_5_1_schedexplain: Crea un script de text pla des de la interfície gràfica d’usuari i programa'l. Els scripts de tasques programades es desen a la carpeta "Scripts programats". Per editar o eliminar tasques programades podeu utilitzar el Programador de tasques del sistema, totes les tasques programades creades per PeaZip es recopilen a la branca "PeaZip" de la biblioteca de tasques.
+txt_5_1_schedok: La programació s'ha desat satisfactòriament
+txt_5_1_schedscripts: Scripts programats desats
 txt_5_1_startdate: Data d'inici
 txt_5_1_starttime: Hora d'inici
 txt_5_1_w1: Diumenge
@@ -303,7 +303,7 @@ txt_5_1_w3: Dimarts
 txt_5_1_w4: Dimecres
 txt_5_1_weekly: Setmanalment
 txt_5_1_weeks: Setmanes
-txt_5_0_bc: Breadcrumb
+txt_5_0_bc: Ruta d'exploració
 txt_5_0_resetpm: Confirmes que vols reestablir l'administrador de contrasenyes? Totes les contrasenyes emmagatzemades a l'administrador de contrasenyes del PeaZip es perdran si ho confirmes.
 txt_5_0_enum: Enumera el contingut de la carpeta
 txt_5_0_music: Música
@@ -311,9 +311,9 @@ txt_5_0_ps: Obre el PowerShell aquí
 txt_5_0_perf: Rendiment
 txt_5_0_pictures: Imatges
 txt_5_0_removeall: Elimina-ho tot
-txt_5_0_resetbookmarks: Reset Bookmarks to default? (Bookmarks can then be customized with Bookmarks > Organize)
+txt_5_0_resetbookmarks: Vols reestablir els marcadors? (Els marcadors es poden personalitzar a Marcadors > Organitza)
 txt_5_0_sh: Historial de la sessió
-txt_5_0_skip: Skip enumerating directories' content in layout
+txt_5_0_skip: Omet enumerar el contingut dels directoris a la maquetació
 txt_5_0_videos: Vídeos
 txt_4_9_frame: Marc
 txt_4_9_listth: Llista i miniatures
@@ -325,7 +325,7 @@ txt_4_8_detailsno: Detalls
 txt_4_8_details: Detalls i miniatures
 txt_4_8_fit: Ajusta a
 txt_4_8_fitl: Ajusta a la més gran
-txt_4_8_flip: Flip
+txt_4_8_flip: Dóna la volta
 txt_4_8_fullscreen: Pantalla completa
 txt_4_8_fun: Funcions
 txt_4_8_h: Altura
@@ -336,10 +336,10 @@ txt_4_8_iconm: Icones i imatges
 txt_4_8_imagemanager: Administrador d'imatges
 txt_4_8_immersive: Immersiu
 txt_4_8_listno: Llista
-txt_4_8_aspect: Maintain aspect ratio
+txt_4_8_aspect: Mantén la relació d'aspecte
 txt_4_8_mirror: Simetria
-txt_4_8_presets: Presets
-txt_4_8_replace: Replace original image(s)? "No" apply the transformation in new file(s).
+txt_4_8_presets: Ajustos predeterminats
+txt_4_8_replace: Vols substituir les imatges originals? "No" aplica la transformació en fitxers nous.
 txt_4_8_resize: Canvia la mida
 txt_4_8_rl: Gira a l'esquerra
 txt_4_8_rr: Gira a la dreta
@@ -357,13 +357,13 @@ txt_4_6_users: Usuaris
 txt_4_5_goupdate: Hi ha una actualització disponible. Vols obrir la web oficial del PeaZip per descarregar l'actualització?
 txt_4_5_b: Part inferior
 txt_4_5_koupdate: No s'han pogut comprovar les actualitzacions, no hi ha connexió amb el servidor d'actualitzacions
-txt_4_5_update: Comprova si hi ha actualitzacions
+txt_4_5_update: Comprova les actualitzacions
 txt_4_5_dock: Ancora
 txt_4_5_l: Esquerra
 txt_4_5_noupdate: El PeaZip està actualitzat
 txt_4_5_properties: Propietats
 txt_4_5_r: Dreta
-txt_4_5_pj: Saved scripts
+txt_4_5_pj: Scripts desats
 txt_4_5_shaddress: Mostra la barra d'adreça
 txt_4_5_shnav: Mostra la barra de navegació
 txt_4_5_shstatus: Mostra la barra d'estat
@@ -372,39 +372,39 @@ txt_4_5_upxpj: Em sap greu, no es pot exportar la definició de la tasca, ja que
 txt_4_5_t: Part superior
 txt_4_4_confremoveall: Vols eliminar tots els fitxers personalitzats del PeaZip (Aplicacions, Preferits, Administrador de contrasenyes)?
 txt_4_4_confremove: Vols eliminar la configuració del PeaZip?
-txt_4_3_pwmanhint: Double click to edit items in password list, rightclick for options, Ctrl+C to copy passwords
+txt_4_3_pwmanhint: Feu doble clic per editar els elements de la llista de contrasenyes, feu clic amb el botó dret per veure les opcions, Ctrl + C per copiar les contrasenyes
 txt_4_3_exppl: Exporta la llista de contrasenyes
-txt_4_3_expple: Encrypted (backup Password Manager)
+txt_4_3_expple: Encriptat (còpia de seguretat del Gestor de Contrasenyes)
 txt_4_3_keeppw: Recorda la contrasenya/fitxer de xifratge durant la sessió actual
-txt_4_3_pwmanpwhint: Setting a password/keyfile (optional) to encrypt password list is recommended, in this way authentication will be required to access to the Password Manager. Password/keyfile can be changed at any time from this form.
+txt_4_3_pwmanpwhint: Es recomana establir una contrasenya o fitxer de xifratge (opcional) per encriptar la llista de contrasenyes, d'aquesta manera es requerirà autenticació per accedir al Gestor de Contrasenyes. La contrasenya o el fitxer de xifratge es poden modificar en qualsevol moment des d'aquest formulari.
 txt_4_3_pwmanmaster: Estableix/canvia la contrasenya global
 txt_4_3_pwmanlist: Llista de contrasenyes
 txt_4_3_pwman: Administrador de contrasenyes
-txt_4_3_pwmancorr: Password Manager seems tampered or corrupted. Keep Password Manager anyway and try to recover current password list, if you trust it? (No will reset Password Manager, recommended)
+txt_4_3_pwmancorr: El Gestor de Contrasenyes sembla manipulat o malmès. Si hi confies, vols conservar-lo igualment i intentar llegir la llista de contrasenyes actual? ("No" reestablirà el Gestor de Contrasenyes (opció recomanada))
 txt_4_3_expplp: Text pla (tots els usuaris)
-txt_4_3_recsrc: Recursive search by default
+txt_4_3_recsrc: Cerca recursiva per defecte
 txt_4_3_resetpm: Vols reestablir l'administrador de contrasenyes? S'eliminaran totes les contrasenyes emmagatzemades
-txt_4_3_breadcrumb: Show Address as breadcrumb
+txt_4_3_breadcrumb: Mostra el camí com a ruta de navegació
 txt_4_2_arcabspath: Utilitza rutes absolutes
-txt_4_1_duplicateshint: "size"/"checksum" string is reported in CRC column for all duplicate candidates found in current directory or search filter
-txt_4_1_adminhint: (HINT: alternatively, you can request UAC elevation to work in protected paths, Alt+F10 or Options > Run as administrator)
-txt_4_1_selected: (selected)
-txt_4_1_duplicatesfound: duplicates found
-txt_4_1_duplicatesfind: Troba duplicats
+txt_4_1_duplicateshint: La "mida" i la "suma de comprovació" s'anoten a la columna CRC per a tots els candidats duplicats que es troben al directori actual o al filtre de cerca
+txt_4_1_adminhint: (SUGGERIMENT: com a alternativa, podeu sol·licitar l'elevació UAC per treballar en ubicacions protegides, Alt + F10 o Opcions > Executa com a administrador)
+txt_4_1_selected: (seleccionat)
+txt_4_1_duplicatesfound: duplicats trobats
+txt_4_1_duplicatesfind: Cerca duplicats
 txt_4_1_runasadmin: Executa com a administrador
 txt_4_1_simplesearch: Cerca bàsica
-txt_4_0_thim: Show picture thumbnails
-txt_3_8_type_description_wim: WIM: Microsoft's disk image format
-txt_3_8_type_description_xz: XZ: powerful file compression based on LZMA2
+txt_4_0_thim: Mostra les miniatures de les imatges
+txt_3_8_type_description_wim: WIM: Format d'imatge del disc de Microsoft
+txt_3_8_type_description_xz: XZ: potent compressor de fitxers basat en LZMA2
 txt_3_7_donations: Donacions
-txt_3_7_nameasparent: Name archive as selected item's parent folder, if multiple items are added
-txt_3_7_tracker: Issue Tracker
+txt_3_7_nameasparent: Anomeneu l'arxiu com la carpeta on es troba l'element seleccionat, si s'afegeixen diversos elements
+txt_3_7_tracker: Suggeriments, errors, sol·licituds
 txt_3_7_sort: Ordena per
-txt_3_7_swapbars: Swap Tool bar / Address bar
-txt_3_7_themedbars: Themed bars
-txt_3_6_ignoredd: Always ignore paths for Drag and Drop extraction
+txt_3_7_swapbars: Barra d'eines d'intercanvi / barra d'adreces
+txt_3_7_themedbars: Barres temàtiques
+txt_3_6_ignoredd: Ignoreu sempre els camins per a l'extracció d'arrossegar i deixar anar
 txt_3_6_close: Tanca
-txt_3_6_resetapps: Do you want to reset Applications (customizable group of programs and scripts to open files with, overriding file associations)?
+txt_3_6_resetapps: Voleu restablir les aplicacions (grup personalitzable de programes i scripts per obrir fitxers, substituint les associacions de fitxers del sistema)?
 txt_3_6_ethemes: Temes existents
 txt_3_5_td: Descarrega temes
 txt_3_5_managecustomthemes: Administrador de temes
@@ -417,34 +417,34 @@ txt_3_3_multi: Selecció múltiple
 txt_3_3_runexp: Obre un programa, fitxers, carpeta o lloc web
 txt_3_3_apppath: Carpeta del PeaZip
 txt_3_3_run: Executa
-txt_3_2_7zutf8nonascii: 7z / p7zip -mcu use UTF8 for file names containing non-ASCII symbols inside .zip files
+txt_3_2_7zutf8nonascii: 7z / p7zip -mcu utilitza UTF8 per als noms de fitxers que continguin símbols que no siguin ASCII dins dels fitxers .zip
 txt_3_2_alltasks: Totes els tasques
 txt_3_2_conf: Configuració
-txt_3_2_donations: Donate to charitable organizations
-txt_3_1_sccenc: 7z/p7zip CONSOLE character encoding
+txt_3_2_donations: Feu una donació a organitzacions benèfiques
+txt_3_1_sccenc: codificació de caràcters 7z/p7zip CONSOLE
 txt_3_1_downloads: Descàrregues
 txt_3_1_lib: Biblioteques
 txt_3_1_more: Més
 txt_3_1_openasarchive: Obre com a arxiu
-txt_3_1_sendto: User’s SendTo menu folder
-txt_3_1_pathexc: La ruta excedeit la mida màxima permesa
+txt_3_1_sendto: Carpeta del menú "Enviar a" de l'usuari
+txt_3_1_pathexc: La ruta excedeix la mida màxima permesa
 txt_3_1_recent: Recents
 txt_3_1_plsmartmin: Executa minimitzat, mostra'l/manten-lo obert només quan sigui necessari
 txt_3_1_src: Cerques
 txt_3_1_systmp: Carpeta temporal de l'usuari
 txt_3_1_languagetools: Tradueix
 txt_3_1_workingdir: Directori de treball
-txt_3_0_nonreadableorpw: Archive is not readable. The archive may not be valid, volumes may be missing, or its table of content could be encrypted. Would you like to try a password?
+txt_3_0_nonreadableorpw: L'arxiu no es pot llegir. És possible que l’arxiu no sigui vàlid, que faltin volums o que la seva taula de contingut estigui xifrada. Voleu provar d'introduir una contrasenya?
 txt_3_0_readablepw: L'arxiu pot estar protegit amb contrasenya
 txt_3_0_configure: Associació de fitxers i integració del menú del sistema
-txt_3_0_resettmp: Reset peazip-tmp
+txt_3_0_resettmp: Reestableix peazip-tmp
 txt_2_9_address: Barra d'adreces
-txt_2_9_adv: Advanced filters are applied when managing any file supported through 7z or FreeArc backends, see documentation, and overrides basic filters (that are used for search functions and are displayed in Bookmarks and History panels)
+txt_2_9_adv: Els filtres avançats s'apliquen quan es gestiona qualsevol fitxer compatible amb els backends 7z o FreeArc, vegeu la documentació, i substitueix els filtres bàsics (que s'utilitzen per a funcions de cerca i que es mostren als panells de Marcadors i Historial)
 txt_2_9_columns: Columnes
 txt_2_9_copyhere: Copia aquí
-txt_2_9_noscan: Don't scan files being added to layout
-txt_2_9_extconsole: Extraction console is available only while browsing archives
-txt_2_9_thl: Highlight buttons
+txt_2_9_noscan: No analitzeu els fitxers que s’afegeixen a la maquetació
+txt_2_9_extconsole: La consola d’extracció només està disponible mentre navegueu pels arxius
+txt_2_9_thl: Destaca els botons
 txt_2_9_home: Directori de l'usuari
 txt_2_9_lt: Gran
 txt_2_9_mt: Mitjà
@@ -454,25 +454,25 @@ txt_2_9_navbar: Barra de navegació
 txt_2_9_none: Cap
 txt_2_9_organize: Organitza
 txt_2_9_public: Públic
-txt_2_9_rec: Recursive: search in subdirectories, may take some time
+txt_2_9_rec: Recursiu: la cerca als subdirectoris pot tardar més
 txt_2_9_selected: Seleccionat
 txt_2_9_setapps: Organitza les aplicacions
 txt_2_9_showmenu: Mostra la barra de menús
 txt_2_9_st: Petit
-txt_2_9_test_pw2G: Test for encryption <2GB archives
+txt_2_9_test_pw2G: Prova d'encriptació d'arxius <2GB
 txt_2_9_vst: Només text
 txt_2_9_toolbar: Barra d'eines
 txt_2_9_tree: Arbre
 txt_2_9_views: Vistes
 txt_2_8_experimental: (experimental)
-txt_2_8_zcopy: (Windows) Copy files in restartable mode, slower copy
-txt_2_8_addvol: Adding entire volume(s) to archive may take long time, continue anyway?
+txt_2_8_zcopy: (Windows) Copia els fitxers en mode reiniciable, la còpia és més lenta
+txt_2_8_addvol: Afegir volums sencers a l'arxiu pot trigar molt de temps, vols continuar igualment?
 txt_2_8_uniterror: No es pot accedir a la unitat
-txt_2_8_cannotconvert: Cannot convert selected archives
-txt_2_8_convertbegin: Continue with compression stage to finalize the conversion?
+txt_2_8_cannotconvert: No es poden convertir els arxius seleccionats
+txt_2_8_convertbegin: Voleu continuar amb la fase de compressió per finalitzar la conversió?
 txt_2_8_convert: Converteix
 txt_2_8_convertexisting: Converteix els fitxers existents
-txt_2_8_convertdelete: Delete files and folders created temporarily for conversion?
+txt_2_8_convertdelete: Vols suprimir fitxers i carpetes creats temporalment per a la conversió?
 txt_2_8_details: Detalls
 txt_2_8_parallel: Executa les tasques en paral·lel quan sigui possible
 txt_2_8_convertnote: In any case original archives were not modified, to let the user in control about keeping or removing them
@@ -606,7 +606,7 @@ txt_type_description_7z: 7Z: feature rich archive format with high compression r
 txt_dvddl: 8.5 GB DVD DL
 txt_7z_exitcode8: 8: Error: not enough memory for requested operation
 txt_abort: Abort scheduled file copy/move operations?
-txt_about: About
+txt_about: Sobre
 txt_action: Acció
 txt_action_hint: Action on open or preview with associated application
 txt_add: Afegeix
@@ -659,7 +659,7 @@ txt_backupexe: Backup executable (recommended)
 txt_bettercompression: millor compressió
 txt_blogs: Blogs
 txt_blowfish: Blowfish448 (blocs de 64 bit)
-txt_bookmarks: Bookmarks
+txt_bookmarks: Marcadors
 txt_browse: Navega
 txt_browser: Navegador
 txt_aborted_error: Browsing archive stopped, it would take too much time. You can narrow the selection using search (F3) or avoiding Flat view mode (F6). You can directly extract, list or test the archive.
@@ -675,7 +675,7 @@ txt_check_hint: Check for casual data corruption; hash algorithms are suitable t
 txt_check: Checksum/hash file(s)
 txt_check_select: Checksum/hash
 txt_clear: Neteja
-txt_clearlayout: Clear layout
+txt_clearlayout: Neteja la maquetació
 txt_pj_hint: Click to import task, reset changes and load up to date task definition from GUI
 txt_autoclose: Close PeaLauncher when task completes
 txt_cl: línia de comandes:
@@ -985,14 +985,14 @@ txt_sample: Sample:
 txt_saveas: Anomena i desa
 txt_savehistory: Desa l'historial
 txt_save_infolder: Save in folder (auto)
-txt_savejob: Save task definition
-txt_savejobdefinition: Save task definition
-txt_savejobdefinition_hint: Save task definition as plain text; you can use it from your scripts
-txt_savelayout: Save layout
+txt_savejob: Desa la definició de la tasca
+txt_savejobdefinition: Desa la definició de la tasca
+txt_savejobdefinition_hint: Desa la definició de la tasca com a text pla; la podràs utilitzar en els teus scripts
+txt_savelayout: Desa la maquetació
 txt_save_winstate: Save main window state
-txt_search: Search (recursive, may take some time)
-txt_searchanddrag: Search and drag here
-txt_searchfor: Search
+txt_search: Cerca (recursivament, pot tardar un cert temps)
+txt_searchanddrag: Cerca i arrossega aquí
+txt_searchfor: Cerca
 txt_nrsearch: Cerca aquí (no recursiu)
 txt_search_hint: Search in archive's subdirectories for matches with filter(s)
 txt_search_web: Cerca en línia
@@ -1025,7 +1025,7 @@ txt_listtest: sorry, list/test operation is not yet implemented for this format
 txt_sortbysel: Sort by selection status
 txt_list_sorting: Ordenant...
 txt_speed: velocitat
-txt_split: Divisió
+txt_split: Múltiples parts
 txt_type_description_split: Split a file with optional integrity check
 txt_split_file: Divideix el fitxer
 txt_list_nostats: no hi ha estadístiques disponibles
@@ -1034,15 +1034,15 @@ txt_level_store: Store
 txt_stream_control: Stream control
 txt_strip: Strip before UPX (recommended)
 txt_keyfile_created: Successfully created KeyFile as:
-txt_suggestpw: Create random password
+txt_suggestpw: Crea una contrasenya aleatòria
 txt_noupx: Symbols stripped, UPX compression omitted
-txt_syntax: Syntax:
-txt_sysbenchmark: System benchmark
-txt_benchmark: System benchmark will take some minutes and will use all available CPU and memory resource. The system may not respond during the benchmark; run it anyway?
-txt_systools: System tools
+txt_syntax: Sintaxi:
+txt_sysbenchmark: Prova de rendiment del sistema
+txt_benchmark: La prova de rendiment del sistema pot tardar alguns minuts i utilitzarà tota la CPU i memòria disponibles. El sistema pot ser que no respongui durant la prova de rendiment; el vols executar igualment?
+txt_systools: Eines del sistema
 txt_tarbefore: TAR before
 txt_type_description_tar: TAR: archiving format mainstream on UNIX systems
-txt_taskman: Task Manager
+txt_taskman: Administrador de tasques
 txt_caption_test: Verifica
 txt_testall: Verifica-ho tot
 txt_testdisp: Verifica els objectes mostrats

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -194,10 +194,10 @@ txt_5_7_pinstalled: INSTAL·LAT
 txt_5_7_pmissing: ABSENT
 txt_5_7_plugin: Falta un complement, el pots instal·lar desde Ajuda > Cerca connectors i complements
 txt_5_6_basic: Basic
-txt_5_6_exarc: Extreu l'arxiu
+txt_5_6_exarc: Extreu un arxiu
 txt_5_6_tab: Obre en una pestanya nova
 txt_5_6_rc: Botó de la dreta per veure les opcions
-txt_5_6_layouts: Maquetacions desades
+txt_5_6_layouts: Vistes desades
 txt_5_6_upexisting: Actualitza l'arxiu existent
 txt_5_6_verbose: Detallat
 txt_5_5_case: (sensible a les majúscules)
@@ -311,7 +311,7 @@ txt_5_0_ps: Obre el PowerShell aquí
 txt_5_0_perf: Rendiment
 txt_5_0_pictures: Imatges
 txt_5_0_removeall: Elimina-ho tot
-txt_5_0_resetbookmarks: Vols reestablir els marcadors? (Els marcadors es poden personalitzar a Marcadors > Organitza)
+txt_5_0_resetbookmarks: Vols reestablir els preferits? (Els preferits es poden personalitzar a Preferits > Organitza)
 txt_5_0_sh: Historial de la sessió
 txt_5_0_skip: Omet enumerar el contingut dels directoris a la maquetació
 txt_5_0_videos: Vídeos
@@ -439,7 +439,7 @@ txt_3_0_readablepw: L'arxiu pot estar protegit amb contrasenya
 txt_3_0_configure: Associació de fitxers i integració del menú del sistema
 txt_3_0_resettmp: Reestableix peazip-tmp
 txt_2_9_address: Barra d'adreces
-txt_2_9_adv: Els filtres avançats s'apliquen quan es gestiona qualsevol fitxer compatible amb els backends 7z o FreeArc, vegeu la documentació, i substitueix els filtres bàsics (que s'utilitzen per a funcions de cerca i que es mostren als panells de Marcadors i Historial)
+txt_2_9_adv: Els filtres avançats s'apliquen quan es gestiona qualsevol fitxer compatible amb els backends 7z o FreeArc, vegeu la documentació, i substitueix els filtres bàsics (que s'utilitzen per a funcions de cerca i que es mostren als panells de Preferits i Historial)
 txt_2_9_columns: Columnes
 txt_2_9_copyhere: Copia aquí
 txt_2_9_noscan: No analitzeu els fitxers que s’afegeixen a la maquetació
@@ -497,8 +497,8 @@ txt_2_7_extfrom: Extraient de l'arxiu:
 txt_2_7_es: Extreu els tipus de fitxers compatibles que no són comprimits, p. ex. executables, MS Office i fitxers OOo
 txt_2_7_eu: Extreu tipus de fitxers no suportats, especificant una utilitat d'extracció personalitzada
 txt_2_7_clipboard: Porta-retalls
-txt_2_7_goarclayout: Vés a la maquetació de compressió
-txt_2_7_goextlayout: Vés a la maquetació d'extracció
+txt_2_7_goarclayout: Vés a la vista de compressió
+txt_2_7_goextlayout: Vés a la vista d'extracció
 txt_2_7_ok: OK
 txt_2_7_drag_archive: vols obrir el fitxer com a nou arxiu? (clica "No" per afegir el fitxer a la finestra actual d'arxivament)
 txt_2_7_oop: Obra la ubicació d'extracció quan finalitzi el procés
@@ -552,7 +552,7 @@ txt_2_4_itemsheight: Redimensiona l'altura dels elements
 txt_2_4_clearclipboard: Neteja el porta-retalls (Esc)
 txt_2_4_wcommons: Commons
 txt_2_4_copyfrom: Copia desde
-txt_2_4_deletebookmarks: Do you want to delete the list of bookmarked files and folders?
+txt_2_4_deletebookmarks: Vols eliminar la llista de fitxers i carpetes preferides?
 txt_2_4_documents: Documents
 txt_2_4_wenc: Encyclopedia
 txt_2_4_extractfrom: Extreu desde
@@ -604,21 +604,21 @@ txt_7z_exitcode7: 7: Error: s'ha obtingut una ordre incorrecta
 txt_cd700: 700 MB CD
 txt_type_description_7z: 7Z: feature rich archive format with high compression ratio
 txt_dvddl: 8.5 GB DVD DL
-txt_7z_exitcode8: 8: Error: not enough memory for requested operation
+txt_7z_exitcode8: 8: Error: no hi ha prou memòria disponible per a la operació sol·licitada
 txt_abort: Abort scheduled file copy/move operations?
 txt_about: Sobre
 txt_action: Acció
 txt_action_hint: Action on open or preview with associated application
 txt_add: Afegeix
-txt_add_existing_archive: Add (if archive exists)
-txt_add_archive: Add archive
-txt_add_files: Add file(s)
-txt_add_folder: Add folder
-txt_add_path: Add path
-txt_add_tolayout: Add selected files and folders to archive's layout
-txt_add_toarchive: Add to archive
-txt_add_tobookmarks: Add to bookmarks
-txt_address_hint: Filter: accepts * and ? wildcards
+txt_add_existing_archive: Afegeix (si l'arxiu existeis)
+txt_add_archive: Afegeix un arxiu
+txt_add_files: Afegeix fitxers
+txt_add_folder: Afegeix una carpeta
+txt_add_path: Afegeix una ubicació
+txt_add_tolayout: Afegeix els fitxers i carpetes seleccionats a la vista d'arxivament
+txt_add_toarchive: Afegeix a un arxiu
+txt_add_tobookmarks: Afegeix als preferits
+txt_address_hint: Filtre: accepta els comodins * i ?
 txt_adv_filters: Filtres avançats
 txt_algo: Algoritme
 txt_all: tot
@@ -652,18 +652,18 @@ txt_attributes: Atributs
 txt_author: Autor
 txt_ren_existing: Reanomena automàticament els fitxers existents
 txt_ren_extracted: Reanomena automàticament els fitxers extrets
-txt_autofolder: Automatically create new folder to extract the archive in?
+txt_autofolder: Vols crear una nova carpeta automàticament per extreure-hi l'arxiu a dins?
 txt_back: Endarrera
 txt_backend: Backend binaries user interface
 txt_backupexe: Backup executable (recommended)
 txt_bettercompression: millor compressió
 txt_blogs: Blogs
 txt_blowfish: Blowfish448 (blocs de 64 bit)
-txt_bookmarks: Marcadors
+txt_bookmarks: Preferits
 txt_browse: Navega
 txt_browser: Navegador
 txt_aborted_error: Browsing archive stopped, it would take too much time. You can narrow the selection using search (F3) or avoiding Flat view mode (F6). You can directly extract, list or test the archive.
-txt_list_browsing: Browsing
+txt_list_browsing: Navegant per
 txt_archive_root: Browsing: archive's root
 txt_type_description_bzip2: BZip2: quite powerful compression, average speed
 txt_pw_empty: Please provide a password (or a keyfile)
@@ -713,11 +713,11 @@ txt_default: per defecte
 txt_default_compression: compressió per defecte
 txt_default_format: Format per defecte
 txt_theme_default: Tema per defecte
-txt_hard_reset_hint: Elimina el fitxer de marcadors
+txt_hard_reset_hint: Elimina el fitxer dels preferits
 txt_desktop: Escriptori
 txt_dictionary: Diccionari
-txt_dirs: carpetes,
-txt_dis: Disambiguation:
+txt_dirs: carpeta/es,
+txt_dis: Desambiguació:
 txt_disk_cleanup: Neteja del disc
 txt_disk_defrag: Desfragmentació del disc
 txt_disk_management: Administració del disc
@@ -725,8 +725,8 @@ txt_dispaly: Mostra els resultats com a
 txt_displayedmnu_obj: mostrats
 txt_displayedobjects: Objectes mostrats
 txt_nocompress: no comprimeixis
-txt_delete: Do you want to delete selected file(s)? The operation can't be undone and files will be not recoverable from recycle bin
-txt_wipe: Do you want to securely delete selected file(s)? The operation can't be undone and files will be not recoverable
+txt_delete: Vols suprimir definitivament els fitxers seleccionats? L’operació no es pot desfer i els fitxers no es podran recuperar des de la paperera de reciclatge
+txt_wipe: Vols suprimir de forma segura els fitxers seleccionats? L’operació no es pot desfer i els fitxers no es podran recuperar ni amb una aplicació de recuperació de fitxers eliminats
 txt_done: Fet
 txt_edit: Edita
 txt_elapsed: transcorregut:
@@ -738,16 +738,16 @@ txt_note: Introdueix una nota o descripció
 txt_random_keys: Introdueix claus aleatòries
 txt_random_keys_hint: Introdueix claus aleatòries (no cal que les recordis més endavant)
 txt_ent: Avaluació de l'entropia
-txt_ent_tools: Move the mouse or use additional entropy sampling tools
+txt_ent_tools: Mou el cursor o utilitza eines addicionals de mostreig d’entropia 
 txt_eqorlarger: Igual o més gran que el fitxer seleccionat
 txt_eqorrecent: Igual o més recent que el fitxer seleccionat
 txt_eqorolder: Igual o més antic que el fitxer seleccionat
 txt_eqorsmaller: Igual o més petit que el fitxer seleccionat
 txt_equal: Igual que el fitxer seleccionat
-txt_erase_hint: Secure delete: overwrite with random data, mask size, rename, finally delete
+txt_erase_hint: Eliminació segura: sobreescriu amb dades aleatòries, emmascara la mida, reanomena i finalment elimina
 txt_extraction_error: Error extracting the selected object. If the archive is password protected please provide it
 txt_exclude_hint: Exclude file(s), one per line; use * and ? wildcards; " and ' delimiters are not needed
-txt_exclusion_recourse: Exclusion filters recurse subdirs
+txt_exclusion_recourse: Filtres d'exclusió amb subdirectoris recursius
 txt_exclusion: Exclou
 txt_exe: Executable
 txt_overwrite_qry: exists in destination path; overwrite with file(s) with same name from source path? (Cancel: skip copying this object)
@@ -760,11 +760,11 @@ txt_ext_nopath: Extreu (sense camí)
 txt_ext_all: Extreu-ho tot
 txt_ext_allhere: Extreu-ho tot aquí
 txt_ext_allto: Extreu-ho tot a
-txt_extopen_custom: Extract and open with custom application
-txt_extopen_with: Extract and open with...
-txt_ext_disp_here: Extract displayed here
-txt_ext_disp: Extract displayed object(s)
-txt_ext_disp_to: Extract displayed object(s) to...
+txt_extopen_custom: Extreu i obre amb una aplicació personalitzada
+txt_extopen_with: Extreu i obre amb...
+txt_ext_disp_here: Extreu els objectes mostrats aquí
+txt_ext_disp: Extreu els objectes mostrats
+txt_ext_disp_to: Extreu els objectes mostrats a...
 txt_ext_here: Extreu-ho aquí
 txt_ext_sel_here: Extreu la selecció aquí
 txt_ext_sel: Extreu els objectes seleccionats
@@ -774,23 +774,23 @@ txt_newfoldermenu: Extreu-ho en una carpeta
 txt_extto: Extreu-ho en un altre lloc...
 txt_level_fast: Ràpid
 txt_fastcompr: compressió ràpida
-txt_fastopen: Fast open routine, stop browsing extremely large archives, use filters instead
+txt_fastopen: Obre una rutina ràpida, atura la navegació en arxius extremadament grans, utilitza filtres
 txt_level_fastest: Més ràpid
 txt_favformats: Formats preferits
 txt_file: Fitxer
 txt_filebrowser: Explorador de fitxers
 txt_filetools: Eines de fitxers
-txt_files: fitxer(s),
+txt_files: fitxer/s,
 txt_nfiles: Fitxers
 txt_fs: Sistema de fitxers
-txt_filters_recourse: filter(s) recurse subdirs
+txt_filters_recourse: filtre(s) amb subdirectoris recursius
 txt_filters: Filtres
 txt_flat: Pla (mostra-ho tot)
 txt_list_flat: Vista plana
 txt_unit_floppy: Disquet
 txt_foldername: Nom de la carpeta
 txt_nfolders: Carpetes
-txt_error_input_multi: format allows a single file as input; you can use "TAR before" switch to save input in a .TAR archive before, otherwise you can chose another format. HINT: chose archive format after had selected input data: "TAR before" switch will be automatically set
+txt_error_input_multi: permet un fitxer únic com a entrada. Pots utilitzar el commutador "Uneix-ho tot en un fitxer TAR abans de comprimir" per desar l'entrada en un arxiu .TAR prèviament, en cas contrari pots triar un altre format. SUGGERIMENT: si selecciones les dades a comprimir abans d'escollir el format de l'arxiu, el commutador "Uneix-ho tot en un fitxer TAR abans de comprimir" es configurarà automàticament
 txt_fwd: Endavant
 txt_list_found: Trobat
 txt_free: Lliure
@@ -798,61 +798,61 @@ txt_free2: lliure
 txt_name_full: Nom complet
 txt_function: Funció
 txt_general: General
-txt_multithreading: Generic multithreading
+txt_multithreading: Processament en paral·lel genèric
 txt_go_browser: Vés a l'explorador de fitxers
 txt_go_path: Explora la ruta (PeaZip)
-txt_guicl: Graphic + console
-txt_guipealauncher: Graphic: wrapped by PeaLauncher
-txt_graphic: Graphic's folder
-txt_gridaltcolor: Grids alternate color
-txt_gridrowheight: Grids row height
-txt_gui: GUI
+txt_guicl: Gràfic + consola
+txt_guipealauncher: Gràfic: wrapped by PeaLauncher
+txt_graphic: Carpeta dels gràfics
+txt_gridaltcolor: Alterna el color de la quadrícula
+txt_gridrowheight: Altura de les files de la quadrícula
+txt_gui: Interfície gràfica d'usuari
 txt_type_description_gzip: GZip: compressió més ràpida
 txt_here: aquí
 txt_list_history: Historial
-txt_homeroot: Computer/archive's root level
+txt_homeroot: Arrel de l'ordinador o de l'arxiu
 txt_quickbrowse_hint: If browsing is stopped the user can narrow the selection using search or filter functions; extract/list/test functions are not affected in any way.
 txt_backupexe_hint: If something goes wrong and lead to a non functional result, you may recover the original executable from the automatic backup copy
-txt_attach: If the mail client supports that command, the archive will be attached to a new mail
+txt_attach: Si el client de correu admet aquesta ordre, l'arxiu s'adjuntarà a un correu nou
 txt_images: Images
 txt_include_hint: Include file(s), one per line; use * and ? wildcards; " and ' delimiters are not needed
 txt_filters_hint: Inclusion and exclusion filters for 7z binary, please carefully read 7-Zip documentation to understand how those filters works
-txt_inclusion_recourse: Inclusion filters recurse subdirs
-txt_inclusion: Include
-txt_error_function: Incorrect function requested
-txt_info: Info
-txt_infoall: Info on all
-txt_infodisp: Info on displayed object(s)
-txt_infosel: Info on selected object(s)
-txt_inputinfo: Input information
-txt_input_list: Input list:
-txt_iop: input, output, parameters
-txt_ipo: input, parameters, output
+txt_inclusion_recourse: Filtres d'inclusió amb subdirectoris recursius
+txt_inclusion: Inclou
+txt_error_function: Funció sol·licitada incorrecta
+txt_info: Informació
+txt_infoall: Informació de tot
+txt_infodisp: Informació dels objectes visibles
+txt_infosel: Informació dels objectes seleccionats
+txt_inputinfo: Introducció d'informació
+txt_input_list: Llista d'entrada:
+txt_iop: entrada, sortida, paràmetres
+txt_ipo: entrada, paràmetres, sortida
 txt_input: entrada:
 txt_integrity: Verifica la integritat
-txt_chunk_size: Invalid custom size, please correct it in a numerical value
+txt_chunk_size: Mida personalitzada invàlida. Si us plau, corregeix-la a un valor numèric
 txt_invertsel: Inverteix la selecció
-txt_type_exe: is a Windows executable, do you want to run it? ("No" to try open it as archive) HINT: some executables may not properly run unless the whole archive is extracted before
-txt_return_to_archive: is currently open; do you want to browse it?
+txt_type_exe: és un executable de Windows, vols executar-lo? (Selecciona "No" per intentar-lo obrir com a arxiu) SUGGERIMENT: alguns executables poden presentar problemes de funcionament si abans no s'extreu la totalitat de l'arxiu
+txt_return_to_archive: està obert actualment. Vols explorar-lo?
 txt_not_accessible: ja no és accessible
 txt_type_unsupported: no és un format d'arxiu suportat
 txt_checkname_failed: no és un nom vàlid.
-txt_not_accessible_list: is not accessible, please check if the file list provided is correct and up to date
+txt_not_accessible_list: no és accessible. Si us plau, comprova si la llista de fitxers és correcta i està actualitzada
 txt_theme_create_error: It was not possible to create the theme, try to use a name valid for a folder as theme name and to chose a writeable path
-txt_theme_exists: yet exists, please provide a different path
+txt_theme_exists: ja existeis. Si us plau, proporciona una ubicació diferent
 txt_job_code: codi de tasca:
-txt_job_definition_saved: Task definition successfully saved in
+txt_job_definition_saved: La definició de la tasca s'ha desat satisfactòriament a
 txt_job_success: La tasca s'ha completat satisfactòriament!
 txt_join: Uneix
-txt_joinfiles: Join files
+txt_joinfiles: Uneix fitxers
 txt_keyfile: Fitxer de xifratge
-txt_keyfile_not_found: Keyfile cannot be found or read. Please chose a different Keyfile.
-txt_keyfile_notcreated: KeyFile not created
-txt_larger: Larger than selected object
-txt_lastused: Last used
-txt_launch: Launch task
-txt_layout: Layout
-txt_filelist_savedas: Layout saved as
+txt_keyfile_not_found: El fitxer de xifrats no s'ha trobat o no s'ha pogut llegir. Si us plau, selecciona'n un altre
+txt_keyfile_notcreated: No s'ha pogut crear el fitxer de xifratge
+txt_larger: Més gran que el fitxer seleccionat
+txt_lastused: Utilitzat per última vegada
+txt_launch: Executa una tasca
+txt_layout: Vista
+txt_filelist_savedas: Vista desada com a
 txt_level: Nivell
 txt_license: Llicència
 txt_caption_list: Llista
@@ -860,76 +860,76 @@ txt_list_details: Llista (amb detalls)
 txt_list_all: Llista-ho tot
 txt_list_disp: Llista els objectes visibles
 txt_list_sel: Llista els objectes seleccionats
-txt_toggle_warning: Listing flat view of path's content may take long time, continue anyway?
-txt_loadfile: Load file
-txt_loadlayout: Load layout
+txt_toggle_warning: Generar la vista plana amb tot el contingut de la ubicació actual pot tardar un cert temps, vols continuar igualment?
+txt_loadfile: Carrega un fitxer
+txt_loadlayout: Carrega una vista
 txt_unit_hd: Disc local
 txt_localization: Idioma
-txt_lpaqver: LPAQ version
-txt_type_description_lpaq: LPAQ: faster version of PAQ, very good compression
-txt_maininterface: Main interface
+txt_lpaqver: versió LPAQ
+txt_type_description_lpaq: LPAQ: versió més ràpida del PAQ, compressió molt bona
+txt_maininterface: Interfície principal
 txt_maxcomp: Modalitat de compressió màxima
 txt_level_maximum: Màxim
-txt_restartrequired: May require restarting the application to be applied
-txt_required_memory: MB of memory required
+txt_restartrequired: Pot requerir reiniciar l'aplicació per aplicar-se
+txt_required_memory: MB de memòria necessària
 txt_method: Mètode
-txt_misc: Misc
+txt_misc: Altres
 txt_modify: Modifica
-txt_morecontrols: More controls (history, bookmarks, ...)
-txt_morerecent: More recent than selected object
-txt_ent_hint: Move the mouse, enter keys in the edit field, load files to collect entropy from the system...
+txt_morecontrols: Més controls (historial, preferits, ...)
+txt_morerecent: Més recent que l'objecte seleccionat
+txt_ent_hint: Desplaça el cursor, presiona tecles del teclat dins del camp d'edició, carrega fitxers de recollida d'entropia des del sistema...
 txt_moveto: Desplaça a...
-txt_mypc: Directori arrel del sistema
+txt_mypc: Aquest ordinador
 txt_list_na: n/a
 txt_name: Nom
 txt_naming: Política de noms
-txt_unit_remote: Network drive
+txt_unit_remote: Unitat de xarxa
 txt_newarchive: Nou arxiu
 txt_cnewfolder: Nova carpeta
 txt_news: Notícies
 txt_no: No
-txt_noinput: No accessible input received
-txt_nocompress_hint: no compression (faster)
-txt_split_noinput: No input selected; please select a file to split
-txt_open_noinput: No input selected; please select an archive (first archive's volume for multi-volume archives)
-txt_list_nomatch: no match
-txt_singlethread: No multithreading
-txt_none2: none
-txt_nonsolid: Non-solid
+txt_noinput: No s'ha rebut cap entrada accessible
+txt_nocompress_hint: sense compressió (més ràpid)
+txt_split_noinput: No s'ha seleccionat cap entrada. Si us plua, selecciona un fitxer a dividir
+txt_open_noinput: No s'ha seleccionat cap entrada. Si us plua, selecciona un arxiu (aquest haurà de ser el primer dels arxius en cas que sigui un conjunt d'arxius multivolum)
+txt_list_nomatch: cap coincidència
+txt_singlethread: Sense processament en paral·lel
+txt_none2: cap
+txt_nonsolid: No-sòlid
 txt_level_normal: Normal
-txt_copy_error: not successfully copied or moved, error code:
+txt_copy_error: no s'ha copiat o mogut satisfactòriament, codi d'error:
 txt_description: Notes
-txt_compare_second: Now select file to be compared with
-txt_peaobj: Object control
-txt_displayed_obj: object(s)
-txt_olderthan: Older than selected object
+txt_compare_second: Ara selecciona el fitxer a comparar
+txt_peaobj: Control d'objectes
+txt_displayed_obj: objecte(s)
+txt_olderthan: Més antic que l'objecte seleccionat
 txt_on: on
 txt_ondblclick: En fer doble clic
 txt_opacity: Opacitat
 txt_open: Obre
 txt_openarchive: Obre un document
 txt_title_open: Obre un document, desencripta'l, uneix-lo...
-txt_open_bookmark: Open bookmark
+txt_open_bookmark: Obre els preferits
 txt_cphere: Executa una ordre aquí
 txt_open_file: Obre un arxiu
 txt_open_files: Obre arxius
 txt_open_path: Obre una ubicació
-txt_opensource: Open source portable archiver
+txt_opensource: Arxivador portable de codi obert
 txt_openwith: Obre amb...
 txt_aborted: Operació avortada
 txt_unit_cd: Unitat òptica
 txt_options: Opcions
-txt_other: Other
-txt_otherparams: Other parameters (free editing)
-txt_oip: output, input, parameters
-txt_opi: output, parameters, input
-txt_output: output:
+txt_other: Altres
+txt_otherparams: Altres paràmetres (edició lliure)
+txt_oip: sortida, entrada, paràmetres
+txt_opi: sortida, paràmetres, entrada
+txt_output: sortida:
 txt_overwrite: Substitueix els fitxers existents
 txt_compressed_size: Empaquetat
 txt_paqver: PAQ version
 txt_type_description_paq: PAQ: slow but extremely powerful compressor
-txt_pio: parameters, input, output
-txt_poi: parameters, output, input
+txt_pio: paràmetres, entrada, sortida
+txt_poi: paràmetres, sortida, entrada
 txt_parameters: Paràmetres:
 txt_error_partial: Partial extraction not implemented for current archive type
 txt_passes: Passes
@@ -940,8 +940,8 @@ txt_un7z_browse_pw_other: potser la contrasenya és incorrecta
 txt_paste: Enganxa
 txt_path: Camí
 txt_pea_appcolor: Application accent
-txt_pea_textcolor: Pea text color
-txt_type_description_pea: PEA: security oriented archive format with fast compression
+txt_pea_textcolor: Color del text del PeaZip
+txt_type_description_pea: PEA: format d'arxivament basat en la seguretat i de compressió ràpida
 txt_peazip_new: PeaZip (instància nova)
 txt_peazip_help: Suport en línia
 txt_peazip_web: Lloc web del PeaZip
@@ -960,8 +960,8 @@ txt_projectadmin: Project administrator:
 txt_type_description_quad: BALZ/QUAD: high-performance ROLZ-based file compressors
 txt_quickdelete: Eliminació ràpida
 txt_quit: Surt
-txt_unit_ram: RAM disk
-txt_read: Read:
+txt_unit_ram: disc RAM
+txt_read: Lectura:
 txt_recentarchives: Arxius recents
 txt_rr_hint: Recovery records allows to try to correct archives in case of data corruption
 txt_search_refine: Refine search filter, accepts ? and * wildcards
@@ -1001,14 +1001,14 @@ txt_securedelete: Eliminació segura
 txt_default_description: Select a function or drag files here
 txt_selectall: Selecciona-ho tot
 txt_selectdir: Selecciona un directori
-txt_selected_obj: selected
-txt_selected_objects: Selected objects
-txt_sfx: Self-extracting
+txt_selected_obj: seleccionat
+txt_selected_objects: Objectes seleccionats
+txt_sfx: Autoextraïble
 txt_sendbymail: Envia per e-mail
-txt_set_defaults: Set application's default parameters
+txt_set_defaults: Estableix els paràmetres per defecte de l'aplicació
 txt_settings: Configuració
 txt_sfx_interface: sfx interface
-txt_showhints: Show hints
+txt_showhints: Mostra els suggeriments
 txt_show_messages: Mostra els missatges informatius
 txt_showpw: Mostra el contigut del camp de la contrasenya
 txt_singlevol: Single volume, do not split
@@ -1016,13 +1016,13 @@ txt_size: Mida
 txt_sizeb: Mida (B)
 txt_skip_existing: Omet els fitxers existents
 txt_slowercomp: compressió més lenta però descompressió igual de ràpida
-txt_smaller: Smaller than selected object
+txt_smaller: Més petit que l'objecte seleccionat
 txt_solid: Solid
 txt_solid_block: Mida del bloc
 txt_solid_auto: Solid, auto-adjust
 txt_solid_extension: Solid, group by extension
 txt_listtest: sorry, list/test operation is not yet implemented for this format
-txt_sortbysel: Sort by selection status
+txt_sortbysel: Ordena segons l'estat de selecció
 txt_list_sorting: Ordenant...
 txt_speed: velocitat
 txt_split: Múltiples parts
@@ -1033,14 +1033,14 @@ txt_status: Estat
 txt_level_store: Store
 txt_stream_control: Stream control
 txt_strip: Strip before UPX (recommended)
-txt_keyfile_created: Successfully created KeyFile as:
+txt_keyfile_created: Fitxer de xifratge creat satisfactòriament com a:
 txt_suggestpw: Crea una contrasenya aleatòria
 txt_noupx: Symbols stripped, UPX compression omitted
 txt_syntax: Sintaxi:
 txt_sysbenchmark: Prova de rendiment del sistema
 txt_benchmark: La prova de rendiment del sistema pot tardar alguns minuts i utilitzarà tota la CPU i memòria disponibles. El sistema pot ser que no respongui durant la prova de rendiment; el vols executar igualment?
 txt_systools: Eines del sistema
-txt_tarbefore: TAR before
+txt_tarbefore: Uneix-ho tot en un fitxer TAR abans de comprimir
 txt_type_description_tar: TAR: archiving format mainstream on UNIX systems
 txt_taskman: Administrador de tasques
 txt_caption_test: Verifica
@@ -1055,14 +1055,14 @@ txt_theme: Tema
 txt_icons_found: Tema carregat satisfactòriament.
 txt_themename: Nom del tema
 txt_icons_not_found: Theme not loaded correctly. Try to switch to the default theme, or to a known working one.
-txt_theme_create_success: theme successfully created in
+txt_theme_create_success: creat satisfactòriament a
 txt_theming: Aparença
 txt_extand_error: Aquesta funció es pot aplicar només a un objecte a la vegada
 txt_threads: Fils
-txt_titlescolor: Titles color
-txt_to: to
-txt_toggle_browseflat: Toggle browse / flat view (show all)
-txt_toggle_historybookmarks: Toggle history/bookmarks
+txt_titlescolor: Color dels títols
+txt_to: a
+txt_toggle_browseflat: Canvia entre la vista de navegació i la vista plana (ho mostra tot sense carpetes)
+txt_toggle_historybookmarks: Canvia entre l'historial i els preferits
 txt_toolbarscolor: Color de les barres
 txt_tools: Eines
 txt_best: prova la millor configuració (més lent)
@@ -1072,9 +1072,9 @@ txt_error_openfile: Unable to open the specified file
 txt_cl_hint: UNACE and UPX always run using console mode; list, test and benchmark tasks always run using GUI mode
 txt_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
 txt_units: unitats
-txt_unit_unknown: Unknown drive type
+txt_unit_unknown: Tipus d'unitat desconeguda
 txt_un7z_pw_untested: Untested
-txt_up: Up
+txt_up: Amunt
 txt_update: Actualitza (si el fitxer existeix)
 txt_type_description_upx: UPX: compress executable files only
 txt_advfilters: Utilitza els filtres avançats
@@ -1088,7 +1088,7 @@ txt_type_ext_uns: s'ha extret satisfactòriament
 txt_websearch: Cerca en línia
 txt_websites: Pàgines web
 txt_word: Word
-txt_write: Write:
+txt_write: Escriptura:
 txt_ramdompw_hint: You can copy the random generated password from here
 txt_exe_hint: You can freely enter executable name and parameters for custom compression, and chose syntax's construction. Please note that you can also manually change command's syntax in "Console" tab.
 txt_pj_hint2: You can import the task's definition from the GUI frontend in the memo field below. Then, you can edit, launch or save it without changing or losing the task defined for the GUI frontend.

--- a/peazip-sources/res/lang/ca.txt
+++ b/peazip-sources/res/lang/ca.txt
@@ -1,9 +1,9 @@
 ﻿=== PeaZip language file ===
-Catalan - Català
+Català
 8.2
-Translated by: Marc Roca Musach
-Last rev. by: Marc Roca Musach
-Last rev.: 20210927
+Traduït per: Marc Roca Musach
+Última revisió per: Marc Roca Musach
+Última revisió el: 20211007
 
 === PeaZip text group ===
 
@@ -20,9 +20,9 @@ txt_8_2_supportedby: Suportat per
 txt_8_1_preparse: Pre-analitzar sempre els arxius
 txt_8_1_bo: Optimització del navegador
 txt_8_1_bop: Les opcions d’optimització del navegador es poden configurar a Opcions >  Configuració, pestanya General, per tal de permetre al navegador mostrar arxius que contenen un gran nombre d’elements.
-txt_8_1_nopreparse: No analitzeu prèviament els arxius
+txt_8_1_nopreparse: No analitzis prèviament els arxius
 txt_8_1_ed: error(s) detectats.
-txt_8_1_togglearc: La visualització plana del contingut de l'arxiu pot tardar molt de temps, vols continuar de totes maneres?
+txt_8_1_togglearc: La visualització plana del contingut de l'arxiu pot tardar molt de temps, voleu continuar igualment?
 txt_8_1_preparsehint: Optimitza el rendiment a base de limitar el pre-anàlisi dels arxius grans. El pre-anàlisi pretén detectar amb antelació possibles problemes en el contingut de l'arxiu.
 txt_8_1_slow: Lent
 txt_8_1_vslow: Molt lent
@@ -31,17 +31,17 @@ txt_8_0_altcol: Alterna el color de la quadrícula
 txt_8_0_forcebrowse: Cerca tipus d’arxius no canònics (contenidors, imatges de disc, instal·ladors, ...)
 txt_8_0_commonalgo: Algoritmes comuns
 txt_8_0_forceconvert: Converteix els tipus d’arxius no canònics
-txt_8_0_defaultactionhint: Acció per defecte en fet doble clic des del sistema sobre un fitxer associat al PeaZip
+txt_8_0_defaultactionhint: Acció per defecte en fer doble clic des del sistema sobre un fitxer associat al PeaZip
 txt_8_0_defaultaction: Acció predeterminada en iniciar
 txt_8_0_enableextand: Activa el submenú "Extreu i obre amb"
 txt_8_0_forcetyping: Força l’escriptura de contrasenyes de manera interactiva
 txt_8_0_setpwopt: Configura les opcions de contrasenya i dels fitxers de xifratge
-txt_8_0_forcetypinghelp: Will run backend binaries in console, cannot browse archives with encrypted filenames. Allows to create scripts that will not run unattended but rather ask user interactively for password.
+txt_8_0_forcetypinghelp: Executarà binaris del backend a la consola, no es poden explorar fitxers amb noms encriptats. Permet crear scripts que s'executaran interactivament i preguntaran la contrasenya a l'usuari.
 txt_7_9_spacing: Espaiat
 txt_7_9_zooming: Proporció d'ampliació
 txt_7_8_changelocalization: Canvia l'idioma del PeaZip
 txt_7_8_custext: Extensió personalitzada
-txt_7_8_destexistfile: La destinació ja conté fitxers processats. Vols substituir-los?
+txt_7_8_destexistfile: La destinació ja conté fitxers processats. Voleu substituir-los?
 txt_7_8_dd: Arrossegar i deixar anar
 txt_7_8_priorityhigh: Alta
 txt_7_8_priorityidle: Quan estigui inactiu
@@ -53,7 +53,7 @@ txt_7_8_tpriority: Prioritat de tasques
 txt_7_8_update: Actualitza
 txt_7_7_noneall: Cap: desactiva la previsualització, l'edició, la funcionalitat d'"arrossega i deixa anar" i l'extracció interactiva
 txt_7_7_nonetemp: Cap, el directori temporal de l'usuari si és necessari
-txt_7_7_outtemp: Output, preview in user's temp
+txt_7_7_outtemp: Sortida, previsualitza a la carpeta temporal de l'usuari
 txt_7_7_sys7zreq: Requereix tenir instal·lat el p7zip-full o equivalent
 txt_7_7_tw: Carpeta de treball temporal per crear arxius, editar-los, previsualitzar-los i extreure'ls amb la funcionalitat "arrossega i deixa anar"
 txt_7_7_sys7z: Utilitza el 7z del sistema del Linux
@@ -69,38 +69,38 @@ txt_7_6_defaultenc: Local, UTF-8 per a símbols addicionals
 txt_7_6_dim: Clar
 txt_7_6_setcurdef: Estableix l'ubicació actual com a ubicació d'extracció per defecte
 txt_7_6_setdef: Estableix una ubicació d'extracció per defecte
-txt_7_6_tadvanced: Sincronitza l'arbre de l'arxiu, manté els elements visitats
+txt_7_6_tadvanced: Sincronitza l'arbre de l'arxiu, conserva els elements visitats
 txt_7_6_tsimple: Sincronitza l'arbre de l'arxiu, simple
 txt_7_6_tacolor: Color del text
 txt_7_5_always: Sempre
 txt_7_5_ask: Pregunta
 txt_7_5_autoclosesingle: Tanca automàticament després de l'extracció si no es realitza cap acció de navegació
 txt_7_5_cutlen: Retalla el nom a una longitud determinada
-txt_7_5_cutlenw: Retalla el nom a una longitud determinada (4..255) els conflictes de noms es poden corregir manualment més tard
+txt_7_5_cutlenw: Retalla el nom a una longitud determinada (4..255) els conflictes de noms es poden corregir manualment més endavant
 txt_7_5_dragnone: No bloquegis el destí
-txt_7_5_specialbrowse: Vols extreure-ho tot per proporcionar al fitxer les dades addicionals que pugui necessitar?
-txt_7_5_ee: Extraieu-ho tot per a tipus de fitxers especials
+txt_7_5_specialbrowse: Voleu extreure-ho tot per proporcionar al fitxer les dades addicionals que pugui necessitar?
+txt_7_5_ee: Extreu-ho tot per a tipus de fitxers especials
 txt_7_5_draghide: Amaga el destí
 txt_7_5_draglh: Bloqueja i amaga el destí
 txt_7_5_draglock: Bloqueja el destí
 txt_7_5_never: Mai
-txt_7_5_repnascii: Substitueix / elimina caràcters que no siguin ASCII
+txt_7_5_repnascii: Substitueix o elimina caràcters que no siguin ASCII
 txt_7_4_comment: Comenta
 txt_7_4_7zfbrotlicomp: Compressió molt ràpida, 7Z Brotli
 txt_7_4_7zfzstandardcomp: Compressió molt ràpida, 7Z Zstandard
 txt_7_4_presetrar: Compressió alta, RAR
-txt_7_4_tkeep: Manté la marca horària de l'arxiu original
+txt_7_4_tkeep: Conserva la marca horària de l'arxiu original
 txt_7_4_lock: Bloqueja l'arxiu
 txt_7_4_locked: bloquejat
-txt_7_4_lockconfirm: Els fitxers bloquejats no es poden modificar més endavant, vols continuar bloquejant aquest arxiu?
+txt_7_4_lockconfirm: Els fitxers bloquejats no es poden modificar més endavant, voleu continuar bloquejant aquest arxiu?
 txt_7_4_recover: Repara l'arxiu
 txt_7_4_tcurr: Estableix la marca horària de l'arxiu des del rellotge actual del sistema
-txt_7_4_setarc: Estableix opcions avançades d'arxiu
+txt_7_4_setarc: Estableix opcions avançades d'arxivament
 txt_7_4_setext: Estableix opcions avançades d'extracció
 txt_7_4_swzipx: Canvia a l'extensió zipx per a arxius ZIP no-Deflate
 txt_7_3_archiveerrors: [l'arxiu pot contenir errors]
-txt_7_3_archiveerrorshint: L'arxiu pot no ser vàlid (a causa de dades perdudes, corrompudes o fora dels estàndards), és possible executar la Verificació per obtenir informació més detallada. Si la taula de l'arxiu està encriptada, es requereix una contrasenya abans de poder-hi navegar.
-txt_7_3_clickextall: Fes clic a "Extreu-ho tot" per habilitar-ho
+txt_7_3_archiveerrorshint: L'arxiu pot no ser vàlid (a causa de dades perdudes, malmeses o fora dels estàndards), és possible executar la Verificació per obtenir informació més detallada. Si la taula de l'arxiu està encriptada, es requereix una contrasenya abans de poder-hi navegar.
+txt_7_3_clickextall: Feu clic a "Extreu-ho tot" per habilitar-ho
 txt_7_3_noconfdel: No em demanis confirmació d'eliminació després de l'arxivament o l'extracció
 txt_7_3_profile7zfastest: Compressió ràpida, 7Z més ràpid
 txt_7_3_maxbr: Maximitza la compressió Brotli utilitzant més memòria (pot ser incompatible amb alguns extractors)
@@ -127,13 +127,13 @@ txt_7_1_renfilesonly: Reanomena només els fitxers
 txt_7_1_typetosearch: Escriu aquí per cercar dins el directori actual
 txt_7_1_type_description_zstd: Zstandard: compressor ràpid de Facebook, descompressió molt ràpida
 txt_7_0_af: Analitza el contingut de les carpetes
-txt_7_0_autoopentar: Obre automàticament un arxiu tar dins un fitxer tar.*
+txt_7_0_autoopentar: Obre automàticament un arxiu TAR dins un fitxer amb extensió ".tar.*"
 txt_7_0_exttmppath: El contingut s'extraurà fora de la carpeta temporal de treball, a: 
 txt_6_9_autou: Actualitza automàticament els fitxers modificats dins d'arxius comprimits
 txt_6_9_forceu: Actualitza els fitxers editats dins l'arxiu comprimit
 txt_6_9_opuns: El tipus d'arxiu no suporta aquesta operació
-txt_6_9_overarch: Vols sobreescriure els fitxers amb el mateix nom que es trobin dins l'arxiu comprimit?
-txt_6_9_uconf: El fitxer previsualitzat ha canviat. Vols actualitzar l'arxiu actual?
+txt_6_9_overarch: Voleu sobreescriure els fitxers que es trobin dins l'arxiu comprimit amb el mateix nom?
+txt_6_9_uconf: El fitxer previsualitzat ha canviat. Voleu actualitzar l'arxiu actual?
 txt_6_8_ndrop: Utilitza l'"arrossega i deixa anar" natiu del Windows
 txt_6_7_nop: (sense previsualització)
 txt_6_6_pdupfound: s'han trobat possibles duplicats (comprovació ràpida aproximada)
@@ -156,7 +156,7 @@ txt_6_5_force: Intenta obrir arxius que contenen errors
 txt_6_5_warning: Avís
 txt_6_5_yes: Sí
 txt_6_5_yesall: Sí a tot
-txt_6_5_np: Ara pots canviar la contrasenya dels arxius convertits per una de nova o deixar-la en blanc per ometre l'encriptació
+txt_6_5_np: Ara podeu canviar la contrasenya dels arxius convertits per una de nova o deixar-la en blanc per ometre l'encriptació
 txt_6_4_absolute: Camí absolut
 txt_6_4_appdirn: Afegeix el nom del directori al final
 txt_6_4_closeallother: Tanca totes les altres pestanyes
@@ -192,7 +192,7 @@ txt_5_8_utf: Els scripts necessiten un entorn UTF-8/Unicode complet
 txt_5_8_fsr: No es suporta aquest format a causa de la restricció de compliment de la política del programari lliure (Opcions > Avançat)
 txt_5_7_pinstalled: INSTAL·LAT
 txt_5_7_pmissing: ABSENT
-txt_5_7_plugin: Falta un complement, el pots instal·lar desde Ajuda > Cerca connectors i complements
+txt_5_7_plugin: Falta un complement, el podeu instal·lar des d'Ajuda > Cerca connectors i complements
 txt_5_6_basic: Basic
 txt_5_6_exarc: Extreu un arxiu
 txt_5_6_tab: Obre en una pestanya nova
@@ -210,7 +210,7 @@ txt_5_5_delete: Elimina caràcters a la posició especificada
 txt_5_5_halt: Apaga el sistema quan es completi la tasca
 txt_5_5_positionw: Suggeriment: 1 per afegir abans del primer caràcter, 2 pel segon, etc... "z" pel final del nom del fitxer
 txt_5_5_positionwd: Suggeriment: 1 eliminar des del primer caràcter inclòs, 2 des del segon... "z" pel final del nom del fitxer
-txt_5_5_replaceneww: Suggeriment: proporciona una nova cadena alfanumèrica buida per eliminar l'anterior
+txt_5_5_replaceneww: Suggeriment: proporcioneu una nova cadena alfanumèrica buida per eliminar l'anterior
 txt_5_5_lower: minúscules
 txt_5_5_replaceoldw: Modifica totes les occurències d'aquesta cadena alfanumèrica o caràcter al nom del fitxer
 txt_5_5_newext: Nova extensió
@@ -243,30 +243,30 @@ txt_5_4_deletearchives: Elimina els arxius després de l'extracció
 txt_5_4_deletefiles: Elimina els fitxers després de la compressió
 txt_5_4_deleteoriginal: El procés d'eliminació, tal i com s'ha establert a la finestra principal, s'afegirà al script.
 txt_5_4_lv: Últim lloc visitat
-txt_5_4_deletearchivesconfirm: Confirmes l'eliminació dels arxius originals?
-txt_5_4_deletefilesconfirm: Confirmes l'eliminació dels fitxers originals?
+txt_5_4_deletearchivesconfirm: Segur que voleu eliminar dels arxius originals?
+txt_5_4_deletefilesconfirm: Segur que voleu eliminar dels fitxers originals?
 txt_5_4_used: Utilitzat
 txt_5_3_profilebest: Compressió extrema, 7Z ultra
 txt_5_3_profileadvanced: Compressió alta, 7Z
 txt_5_3_profilenormal: Compressió mitjana, ZIP (compatible amb la majoria d'extractors)
 txt_5_3_profileveryfast: Compressió ràpida, ZIP ràpid (compatible amb la majoria d'extractors)
 txt_5_3_profilepassword: Protegeix amb contrasenya, format 7Z
-txt_5_3_profile10mb: Manté el resultat per sota dels 25 MB, per les limitacions d'enviament
+txt_5_3_profile10mb: Mantén el resultat per sota dels 25 MB, per les limitacions d'enviament
 txt_5_3_profilesfx: Auto-extraïble, el destinatari no necessitarà cap programa d'extracció
 txt_5_3_cml: Idioma del menú contextual del sistema
-txt_5_3_cmlmessage: Fes doble clic a l'idioma del menú contextual desitjat i confirma l'aplicació al registre. Aquesta configuració necessita tornar-se a aplicar quan s'instal·la o s'actualitza l'aplicació, o després d'utilitzar l'assistent d'integració amb el sistema.
+txt_5_3_cmlmessage: Feu doble clic a l'idioma del menú contextual desitjat i confirmeu l'aplicació al registre. Aquesta configuració necessita tornar-se a aplicar quan s'instal·la o s'actualitza l'aplicació, o després d'utilitzar l'assistent d'integració amb el sistema.
 txt_5_3_exc: Els filtres d'exclusió prevalen sobre els filtres d'inclusió
 txt_5_3_ia: Inclou també
 txt_5_3_io: Inclou només
 txt_5_3_rec: Subdirectoris recursius
-txt_5_3_resetsi: Vols reconfigurar la integració amb el sistema (menú contextual, Enviar a, associacions de fitxers)?
+txt_5_3_resetsi: Voleu reconfigurar la integració amb el sistema (menú contextual, Enviar a, associacions de fitxers)?
 txt_5_2_oadd: Comprimeix a la ubicació original
-txt_5_2_zerodelete: Vols eliminar i reemplaçar els fitxers seleccionats amb 0? La operació no es pot desfer i els fitxers no es podran recuperar
-txt_5_2_zfree: Vols reemplaçar l'espai lliure d'aquesta unitat amb 0?
-txt_5_2_sdfree: Vols esborrar l'espai lliure d'aquesta unitat de forma segura?
+txt_5_2_zerodelete: Voleu eliminar i reemplaçar els fitxers seleccionats amb 0? La operació no es pot desfer i els fitxers no es podran recuperar
+txt_5_2_zfree: Voleu reemplaçar l'espai lliure d'aquesta unitat amb 0?
+txt_5_2_sdfree: Voleu esborrar l'espai lliure d'aquesta unitat de forma segura?
 txt_5_2_oext: Extreu a la ubitació original
 txt_5_2_securedeletefree: Elimina l'espai lliure de forma segura
-txt_5_2_free: Aquesta operació pot tardar uns minuts i, si es realitza sovint, pot desgastar ràpidament discs de memòria flash
+txt_5_2_free: Aquesta operació pot tardar uns minuts i, si es realitza sovint, pot desgastar ràpidament discs de memòria flash (per exemple, targetes extraïbles SD)
 txt_5_2_zerofiles: Reemplaça amb 0
 txt_5_2_zerofree: Reemplaça l'espai lliure amb 0
 txt_5_1_schedadd: Afegeix una programació
@@ -290,7 +290,7 @@ txt_5_1_onstart: A l'engegada
 txt_5_1_once: Una vegada
 txt_5_1_w7: Dissabte
 txt_5_1_schedule: Programa
-txt_5_1_schedexplain: Crea un script de text pla des de la interfície gràfica d’usuari i programa'l. Els scripts de tasques programades es desen a la carpeta "Scripts programats". Per editar o eliminar tasques programades podeu utilitzar el Programador de tasques del sistema, totes les tasques programades creades per PeaZip es recopilen a la branca "PeaZip" de la biblioteca de tasques.
+txt_5_1_schedexplain: Creeu un script de text pla des de la interfície gràfica d’usuari i programeu-lo. Els scripts de tasques programades es desen a la carpeta "Scripts programats". Per editar o eliminar tasques programades podeu utilitzar el Programador de tasques del sistema, totes les tasques programades creades per PeaZip es recopilen a la branca "PeaZip" de la biblioteca de tasques.
 txt_5_1_schedok: La programació s'ha desat satisfactòriament
 txt_5_1_schedscripts: Scripts programats desats
 txt_5_1_startdate: Data d'inici
@@ -304,14 +304,14 @@ txt_5_1_w4: Dimecres
 txt_5_1_weekly: Setmanalment
 txt_5_1_weeks: Setmanes
 txt_5_0_bc: Ruta d'exploració
-txt_5_0_resetpm: Confirmes que vols reestablir l'administrador de contrasenyes? Totes les contrasenyes emmagatzemades a l'administrador de contrasenyes del PeaZip es perdran si ho confirmes.
+txt_5_0_resetpm: Segur que voleu reestablir l'administrador de contrasenyes? Totes les contrasenyes emmagatzemades a l'administrador de contrasenyes del PeaZip es perdran si ho confirmeu.
 txt_5_0_enum: Enumera el contingut de la carpeta
 txt_5_0_music: Música
 txt_5_0_ps: Obre el PowerShell aquí
 txt_5_0_perf: Rendiment
 txt_5_0_pictures: Imatges
 txt_5_0_removeall: Elimina-ho tot
-txt_5_0_resetbookmarks: Vols reestablir els preferits? (Els preferits es poden personalitzar a Preferits > Organitza)
+txt_5_0_resetbookmarks: Voleu reestablir els preferits? (Els preferits es poden personalitzar a Preferits > Organitza)
 txt_5_0_sh: Historial de la sessió
 txt_5_0_skip: Omet enumerar el contingut dels directoris a la vista
 txt_5_0_videos: Vídeos
@@ -329,38 +329,38 @@ txt_4_8_flip: Dóna la volta
 txt_4_8_fullscreen: Pantalla completa
 txt_4_8_fun: Funcions
 txt_4_8_h: Altura
-txt_4_8_keeparchive: Manté l'arxiu
-txt_4_8_noresize: Manté la mida original
+txt_4_8_keeparchive: Conserva l'arxiu
+txt_4_8_noresize: Conserva la mida original
 txt_4_8_iconl: Imatges grans
 txt_4_8_iconm: Icones i imatges
 txt_4_8_imagemanager: Administrador d'imatges
 txt_4_8_immersive: Immersiu
 txt_4_8_listno: Llista
-txt_4_8_aspect: Mantén la relació d'aspecte
+txt_4_8_aspect: Conserva la relació d'aspecte
 txt_4_8_mirror: Simetria
 txt_4_8_presets: Ajustos predeterminats
-txt_4_8_replace: Vols substituir les imatges originals? "No" aplica la transformació en fitxers nous.
+txt_4_8_replace: Voleu substituir les imatges originals? "No" aplica la transformació en fitxers nous.
 txt_4_8_resize: Canvia la mida
 txt_4_8_rl: Gira a l'esquerra
 txt_4_8_rr: Gira a la dreta
 txt_4_8_stop: Atura
 txt_4_8_t: Transforma
 txt_4_8_w: Amplada
-txt_4_7_pk: Genera una contrasenya / fitxer de xifratge aleatori/a
+txt_4_7_pk: Genera una contrasenya o fitxer de xifratge aleatori
 txt_4_7_spchar: Limita els caràcters a lletres i números
-txt_4_7_recycleask: Vols moure els fitxers seleccionats a la paperera de reciclatge?
+txt_4_7_recycleask: Voleu traslladar els fitxers seleccionats a la paperera de reciclatge?
 txt_4_7_recycle: Desplaça a la paperera de reciclatge
 txt_4_7_pcomp: Compressió potencial
 txt_4_6_am: Administrador d'arxius
 txt_4_6_fm: Administrador de fitxers
 txt_4_6_users: Usuaris
-txt_4_5_goupdate: Hi ha una actualització disponible. Vols obrir la web oficial del PeaZip per descarregar l'actualització?
+txt_4_5_goupdate: Hi ha una actualització disponible. Voleu obrir la web oficial del PeaZip per descarregar l'actualització?
 txt_4_5_b: Part inferior
 txt_4_5_koupdate: No s'han pogut comprovar les actualitzacions, no hi ha connexió amb el servidor d'actualitzacions
 txt_4_5_update: Comprova les actualitzacions
 txt_4_5_dock: Ancora
 txt_4_5_l: Esquerra
-txt_4_5_noupdate: El PeaZip està actualitzat
+txt_4_5_noupdate: El PeaZip està actualitzat!
 txt_4_5_properties: Propietats
 txt_4_5_r: Dreta
 txt_4_5_pj: Scripts desats
@@ -370,8 +370,8 @@ txt_4_5_shstatus: Mostra la barra d'estat
 txt_4_5_shtool: Mostra la barra d'eines
 txt_4_5_upxpj: Em sap greu, no es pot exportar la definició de la tasca, ja que aquesta acció o opció requereix executar múltiples ordres diferents
 txt_4_5_t: Part superior
-txt_4_4_confremoveall: Vols eliminar tots els fitxers personalitzats del PeaZip (Aplicacions, Preferits, Administrador de contrasenyes)?
-txt_4_4_confremove: Vols eliminar la configuració del PeaZip?
+txt_4_4_confremoveall: Voleu eliminar tots els fitxers personalitzats del PeaZip (Aplicacions, Preferits, Administrador de contrasenyes)?
+txt_4_4_confremove: Voleu eliminar la configuració del PeaZip?
 txt_4_3_pwmanhint: Feu doble clic per editar els elements de la llista de contrasenyes, feu clic amb el botó dret per veure les opcions, Ctrl + C per copiar les contrasenyes
 txt_4_3_exppl: Exporta la llista de contrasenyes
 txt_4_3_expple: Encriptat (còpia de seguretat del Gestor de Contrasenyes)
@@ -380,10 +380,10 @@ txt_4_3_pwmanpwhint: Es recomana establir una contrasenya o fitxer de xifratge (
 txt_4_3_pwmanmaster: Estableix/canvia la contrasenya global
 txt_4_3_pwmanlist: Llista de contrasenyes
 txt_4_3_pwman: Administrador de contrasenyes
-txt_4_3_pwmancorr: El Gestor de Contrasenyes sembla manipulat o malmès. Si hi confies, vols conservar-lo igualment i intentar llegir la llista de contrasenyes actual? ("No" reestablirà el Gestor de Contrasenyes (opció recomanada))
+txt_4_3_pwmancorr: Sembla que s'ha manipulat o malmès el Gestor de Contrasenyes. Si hi confieu, voleu conservar-lo igualment i intentar llegir la llista de contrasenyes actual? ("No" reestablirà el Gestor de Contrasenyes (opció recomanada))
 txt_4_3_expplp: Text pla (tots els usuaris)
 txt_4_3_recsrc: Cerca recursiva per defecte
-txt_4_3_resetpm: Vols reestablir l'administrador de contrasenyes? S'eliminaran totes les contrasenyes emmagatzemades
+txt_4_3_resetpm: Voleu reestablir l'administrador de contrasenyes? S'eliminaran totes les contrasenyes emmagatzemades
 txt_4_3_breadcrumb: Mostra el camí com a ruta de navegació
 txt_4_2_arcabspath: Utilitza rutes absolutes
 txt_4_1_duplicateshint: La "mida" i la "suma de comprovació" s'anoten a la columna CRC per a tots els candidats duplicats que es troben al directori actual o al filtre de cerca
@@ -397,14 +397,14 @@ txt_4_0_thim: Mostra les miniatures de les imatges
 txt_3_8_type_description_wim: WIM: Format d'imatge del disc de Microsoft
 txt_3_8_type_description_xz: XZ: potent compressor de fitxers basat en LZMA2
 txt_3_7_donations: Donacions
-txt_3_7_nameasparent: Anomeneu l'arxiu com la carpeta on es troba l'element seleccionat, si s'afegeixen diversos elements
+txt_3_7_nameasparent: Anomena l'arxiu igual que la carpeta on es troba l'element seleccionat, si s'afegeixen diversos elements
 txt_3_7_tracker: Suggeriments, errors, sol·licituds
 txt_3_7_sort: Ordena per
 txt_3_7_swapbars: Intercanvia la barra d'eines i la barra d'adreces
 txt_3_7_themedbars: Barres temàtiques
 txt_3_6_ignoredd: Ignora sempre els camins per a l'extracció d'arrossegar i deixar anar
 txt_3_6_close: Tanca
-txt_3_6_resetapps: Vols restablir les aplicacions (grup personalitzable de programes i scripts per obrir fitxers, substituint les associacions de fitxers del sistema)?
+txt_3_6_resetapps: Voleu restablir les aplicacions (grup personalitzable de programes i scripts per obrir fitxers, substituint les associacions de fitxers del sistema)?
 txt_3_6_ethemes: Temes existents
 txt_3_5_td: Descarrega temes
 txt_3_5_managecustomthemes: Administrador de temes
@@ -442,7 +442,7 @@ txt_2_9_address: Barra d'adreces
 txt_2_9_adv: Els filtres avançats s'apliquen quan es gestiona qualsevol fitxer compatible amb els backends 7z o FreeArc, vegeu la documentació, i substitueix els filtres bàsics (que s'utilitzen per a funcions de cerca i que es mostren als panells de Preferits i Historial)
 txt_2_9_columns: Columnes
 txt_2_9_copyhere: Copia aquí
-txt_2_9_noscan: No analitzeu els fitxers que s’afegeixen a la maquetació
+txt_2_9_noscan: No analitzeu els fitxers que s’afegeixen a la visualització
 txt_2_9_extconsole: La consola d’extracció només està disponible mentre navegueu pels arxius
 txt_2_9_thl: Destaca els botons
 txt_2_9_home: Directori de l'usuari
@@ -466,17 +466,17 @@ txt_2_9_tree: Arbre
 txt_2_9_views: Vistes
 txt_2_8_experimental: (experimental)
 txt_2_8_zcopy: (Windows) Copia els fitxers en mode reiniciable, la còpia és més lenta
-txt_2_8_addvol: Afegir volums sencers a l'arxiu pot trigar molt de temps, vols continuar igualment?
+txt_2_8_addvol: Afegir volums sencers a l'arxiu pot trigar molt de temps, voleu continuar igualment?
 txt_2_8_uniterror: No es pot accedir a la unitat
 txt_2_8_cannotconvert: No es poden convertir els arxius seleccionats
 txt_2_8_convertbegin: Voleu continuar amb la fase de compressió per finalitzar la conversió?
 txt_2_8_convert: Converteix
 txt_2_8_convertexisting: Converteix els fitxers existents
-txt_2_8_convertdelete: Vols suprimir fitxers i carpetes creats temporalment per a la conversió?
+txt_2_8_convertdelete: Voleu suprimir fitxers i carpetes creats temporalment per a la conversió?
 txt_2_8_details: Detalls
 txt_2_8_parallel: Executa les tasques en paral·lel quan sigui possible
 txt_2_8_convertnote: En qualsevol cas, els arxius originals no s'han modificat, per tal de permetre a l'usuari controlar la seva conservació o eliminació
-txt_2_8_custom: no es suporta directament amb el PeaZip, però a la fase d'extracció pots configurar PeaZip per gestionar tipus de fitxers personalitzats a la pestanya "Avançat". Vols continuar obrint aquest fitxer?
+txt_2_8_custom: no es suporta directament amb el PeaZip, però a la fase d'extracció pots configurar PeaZip per gestionar tipus de fitxers personalitzats a la pestanya "Avançat". Voleu continuar obrint aquest fitxer?
 txt_2_8_unitrecommend: Es recomana extreure (Botó dret > Extreu els objectes seleccionats) o obrir sistemes de fitxers des de l'arrel de l'ordinador (Eines del sistema > Obre la unitat com a arxiu)
 txt_2_8_viewasarchive: Obre la unitat com a arxiu
 txt_2_8_nounit: No s'ha seleccionat cap unitat
@@ -491,16 +491,16 @@ txt_2_7_separate: Afegeix cada objecte a un arxiu separat
 txt_2_7_pwsupported: arxivant amb contrasenya
 txt_2_7_cancel: Cancel·la
 txt_2_7_encfn: Encripta també els noms dels fitxers (si el format ho suporta)
-txt_2_7_setpw: Introdueix una contrasenya / fitxer de xifratge
+txt_2_7_setpw: Introdueix una contrasenya o fitxer de xifratge
 txt_2_7_ext: Extraient:
 txt_2_7_extfrom: Extraient de l'arxiu:
-txt_2_7_es: Extreu els tipus de fitxers compatibles que no són comprimits, p. ex. executables, MS Office i fitxers OOo
+txt_2_7_es: Extreu els tipus de fitxers compatibles que no són comprimits, per exemple, executables, MS Office i fitxers OOo
 txt_2_7_eu: Extreu tipus de fitxers no suportats, especificant una utilitat d'extracció personalitzada
 txt_2_7_clipboard: Porta-retalls
 txt_2_7_goarclayout: Vés a la vista de compressió
 txt_2_7_goextlayout: Vés a la vista d'extracció
 txt_2_7_ok: D'acord
-txt_2_7_drag_archive: vols obrir el fitxer com a nou arxiu? (clica "No" per afegir el fitxer a la finestra actual d'arxivament)
+txt_2_7_drag_archive: voleu obrir el fitxer com a nou arxiu? (feu clic a "No" per afegir el fitxer a la finestra actual d'arxivament)
 txt_2_7_oop: Obra la ubicació d'extracció quan finalitzi el procés
 txt_2_7_validatefn: L'operació s'ha aturat, s'ha detectat un nom de fitxer no vàlid:
 txt_2_7_validatecl:  L'operació s'ha aturat, s'ha detectat una ordre potencialment perillosa (p. ex. concatenació d'ordres prohibides dins del programa):
@@ -508,19 +508,19 @@ txt_2_7_output: Sortida
 txt_2_7_pwnotset: Contrasenya no definida
 txt_2_7_pwarcset: Contrasenya definida
 txt_2_7_pwextset: Contrasenya definida, és possible extreure, llistar i verificar arxius xifrats
-txt_2_7_archivehint: Arrossega fitxers i carpetes aquí per arxivar-los, o fes clic amb el botó dret per obtenir més opcions
-txt_2_7_exthint: Arrossega arxius comprimits aquí per extreure'ls, o fes clic amb el botó dret per obtenir més opcions
+txt_2_7_archivehint: Arrossegueu fitxers i carpetes aquí per arxivar-los, o feu clic amb el botó dret per obtenir més opcions
+txt_2_7_exthint: Arrossegueu arxius comprimits aquí per extreure'ls, o feu clic amb el botó dret per obtenir més opcions
 txt_2_7_setadvf: Estableix filtres avançats
 txt_2_7_selpath: Camí de l'element seleccionat
 txt_2_7_separateerror: No es poden importar les ordres de la tasca mentre la opció "Afegeix cada objecte a un arxiu separat" està activada, ja que la tasca s'executa com a múltiples ordres diferents
-txt_2_7_noinput: La vista és buida: utilitza "Afegeix fitxers" o "Carrega una vista" per omplir la llista d’arxius que s’extreuran
+txt_2_7_noinput: La vista és buida: utilitzeu "Afegeix fitxers" o "Carrega una vista" per omplir la llista d’arxius que s’extreuran
 txt_2_7_dirsize: No es comprova la mida del contingut de les carpetes per calcular la mida total
-txt_2_7_un7z_browse_flat: prova la vista plana (F6)
+txt_2_7_un7z_browse_flat: proveu la vista plana (F6)
 txt_2_7_updating: S'està actualitzant l'arxiu existent
 txt_2_6_folders: (carpetes)
 txt_2_6_advanced: Avançat
-txt_2_6_plalways: Mantén-lo sempre obert per inspeccionar l'informe de la tasca
-txt_2_6_plsmart: Mantén-lo obert només si cal (informes d'errors, llista o proves)
+txt_2_6_plalways: Conserva'l sempre obert per inspeccionar l'informe de la tasca
+txt_2_6_plsmart: Conserva'l obert només si cal (informes d'errors, llista o proves)
 txt_2_5_sessionio: (aquesta sessió)
 txt_2_5_advanced: Edició avançada: col·loqueu espais entre les cadenes de paràmetres i el nom del fitxer si cal
 txt_2_5_basic: Edició bàsica: aplicació i paràmetres abans de la introducció del nom
@@ -528,7 +528,7 @@ txt_2_5_cannotrun: No es pot executar
 txt_2_5_custeditors: Editors personalitzats, reproductors, antivirus, etc ... (sobreescriu les associacions de fitxers del sistema)
 txt_2_5_delete: Suprimeix
 txt_2_5_delete_fromarchive: Suprimeix de l'arxiu
-txt_2_5_langflag: Mostra el nom de l'objecte arxivat com a text UTF-8; desmarca aquesta opció per substituir els caràcters especials per "?"
+txt_2_5_langflag: Mostra el nom de l'objecte arxivat com a text UTF-8; desmarqueu aquesta opció per substituir els caràcters especials per "?"
 txt_2_5_encpj: Codifica la definició de tasques com a text UTF-8
 txt_2_5_execommand: Executable o ordre
 txt_2_5_help: Ajuda
@@ -537,7 +537,7 @@ txt_2_5_mini_help: Tutorial d'ajuda
 txt_2_5_offline_help: Ajuda del PeaZip
 txt_2_5_tray: Minimitza a la safata del sistema
 txt_2_5_remove: Elimina
-txt_2_5_hintpaths: Fes clic amb el botó de la dreta per per obrir les rutes del sistema y de l'usuari
+txt_2_5_hintpaths: Feu clic amb el botó dret per obrir les rutes del sistema i de l'usuari
 txt_2_5_selectapp: Selecciona una aplicació
 txt_2_5_strafter: Cadena alfanumèrica després del nom d'entrada
 txt_2_5_strbefore: Cadena alfanumèrica abans del nom d'entrada
@@ -552,22 +552,22 @@ txt_2_4_itemsheight: Redimensiona l'altura dels elements
 txt_2_4_clearclipboard: Neteja el porta-retalls (Esc)
 txt_2_4_wcommons: Commons
 txt_2_4_copyfrom: Copia desde
-txt_2_4_deletebookmarks: Vols eliminar la llista de fitxers i carpetes preferides?
+txt_2_4_deletebookmarks: Voleu eliminar la llista de fitxers i carpetes preferides?
 txt_2_4_documents: Documents
 txt_2_4_wenc: Encyclopedia
 txt_2_4_extractfrom: Extreu desde
 txt_2_4_hexp: Previsualització hex
 txt_2_4_operation: Operació
-txt_2_4_path: la ubicació no es pot escriure (p. ex. només lectura). Vols seleccionar una altra ubicació d'extracció escrivible?
+txt_2_4_path: la ubicació no es pot escriure (potser té permisos de només lectura). Voleu seleccionar una altra ubicació d'extracció escrivible?
 txt_2_4_removefromclipboard: Elimina del porta-retalls
-txt_2_4_stdclip: Estàndard: mantén una única selecció al porta-retalls, esborra les operacions de retall en enganxar
+txt_2_4_stdclip: Estàndard: conserva una única selecció al porta-retalls, esborra les operacions de retall en enganxar
 txt_2_4_totalmem: memòria total
 txt_2_4_gvideo: Vídeo
 txt_2_4_wbook: Wikibook
 txt_2_4_wnews: Wikinews
 txt_2_4_wsrc: Wikisource
 txt_2_4_wdict: Wiktionary
-txt_2_3_pw_errorchar: no es recomana utilitzar les cometes a les contrasenyes (al PeaZip i als scripts). Si necessites crear o extreure un arxiu amb aquesta contrasenya, pots ometre aquest missatge i se't demanarà que introdueixis la contrasenya de forma interactiva des de la consola.
+txt_2_3_pw_errorchar: no es recomana utilitzar les cometes a les contrasenyes (al PeaZip i als scripts). Si necessiteu crear o extreure un arxiu amb aquesta contrasenya, podeu ometre aquest missatge i se us demanarà que introduïu la contrasenya de forma interactiva des de la consola.
 txt_2_3_envstr: Mostra les variables d'entorn
 txt_2_3_never_pw: No demanis cap contrasenya
 txt_2_3_home: Directori de l'usuari
@@ -576,7 +576,7 @@ txt_2_3_test_pw100: Verifica si es poden encriptar, arxius <100MB
 txt_2_3_test_pw: Verifica si es poden encriptar (pot ser un procés lent)
 txt_exclude_recourse: Recursiu (explou les subcarpetes)
 txt_action_extopen: Acció de "Extreu i obre amb l'aplicació associada"
-txt_error_passwordnotmatch: Els camps de contrasenya i confirmació de la contrasenya no coincideixen, si us plau, corregeir-los
+txt_error_passwordnotmatch: Els camps de contrasenya i confirmació de la contrasenya no coincideixen, si us plau, reviseu-los
 txt_action_preview: Acció de "Previsualitza amb l'aplicació associada"
 txt_preview_hint: L'acció "Previsualitza" realitza la mateixa funció que "Extreu i obre", però en un directori temporal que s'elimina automàticament quan es tanca l'arxiu.
 txt_better: (millor)
@@ -592,10 +592,10 @@ txt_7z_exitcodeunknown: : Error de tasca desconegut
 txt_list_isfolder:  [carpeta]
 txt_none: <cap>
 txt_fd: 1.44 MB Disquet
-txt_7z_exitcode1: 1: Avís: no s'han produït errors fatals, però alguns falten alguns fitxers o estan bloquejats
+txt_7z_exitcode1: 1: Avís: no s'han produït errors fatals, però falten alguns fitxers o estan bloquejats
 txt_attach10: adjunt de 10 MB
 txt_7z_exitcode2: 2: S'ha produït un error fatal
-txt_7z_exitcode255: 255: L'usuari ha interromput la tasca
+txt_7z_exitcode255: 255: L'usuari ha aturat la tasca
 txt_fat32: 4 GB Fitxer FAT32
 txt_dvd: 4.7 GB DVD
 txt_attach5: adjunt de 5 MB
@@ -605,7 +605,7 @@ txt_cd700: 700 MB CD
 txt_type_description_7z: 7Z: format amb una alta capacitat de compressió i moltes característiques de configuració
 txt_dvddl: 8.5 GB DVD DL
 txt_7z_exitcode8: 8: Error: no hi ha prou memòria disponible per a la operació sol·licitada
-txt_abort: Vols cancel·lar les operacions programades de còpia i desplaçament de fitxers?
+txt_abort: Voleu cancel·lar les operacions programades de còpia i desplaçament de fitxers?
 txt_about: Sobre
 txt_action: Acció
 txt_action_hint: Acció en obrir o previsualitzar amb l'aplicació associada
@@ -634,7 +634,7 @@ txt_ignore_ext: Ignora sempre els camins per "Extreu i..."
 txt_ignore_disp: Ignora sempre els camins per "Extreu els visibles..."
 txt_ignore_sel: Ignora sempre els camins per "Extreu els seleccionats..."
 txt_key_hint: Afegeix el hash del fitxer de xifratge a la contrasenya. El PeaZip i altres aplicacions poden desxifrar l'arxiu seguint el mateix estàndard o introduint el hash com a part de la contrasenya
-txt_timestamp: Afegeix la marca horària al nom
+txt_timestamp: Afegeix la marca horària al nom del fitxer
 txt_appoptions: Opcions de l'aplicació
 txt_type_description_arc: ARC: arxivador experimental, potent, eficient i amb moltes característiques
 txt_archive: Arxiu
@@ -645,14 +645,14 @@ txt_tarbefore_hint: Uneix-ho tot en un fitxer TAR abans de comprimir-ho al forma
 txt_archive_hint: Arxiva, comprimeix, divideix i desa fitxers, carpetes i volums privats
 txt_compressionratio_hint: Ràtio de compressió de l'arxiu
 txt_archiving: Arxivant:
-txt_cl_long: Els arguments semblen superar la mida màxima que pot passar la interfície gràfica del PeaZip, selecciona menys fitxers d'entrada (és a dir, selecciona carpetes en lloc de fitxers individuals)
+txt_cl_long: Els arguments semblen superar la mida màxima que pot passar la interfície gràfica del PeaZip, seleccioneu menys fitxers d'entrada (és a dir, seleccioneu carpetes en comptes de fitxers individuals)
 txt_overwrite_askbefore: Pregunta'm abans de substituir fitxers (a la consola)
 txt_associated: Aplicació associada
 txt_attributes: Atributs
 txt_author: Autor
 txt_ren_existing: Reanomena automàticament els fitxers existents
 txt_ren_extracted: Reanomena automàticament els fitxers extrets
-txt_autofolder: Vols crear una nova carpeta automàticament per extreure-hi l'arxiu a dins?
+txt_autofolder: Voleu crear una nova carpeta automàticament per extreure-hi l'arxiu a dins?
 txt_back: Endarrera
 txt_backend: Interfície d'usuari dels binaris del backend
 txt_backupexe: Conserva l'executable (recomanat)
@@ -664,20 +664,20 @@ txt_browse: Navega
 txt_browser: Navegador
 txt_aborted_error: S'ha aturat la navegació de l'arxiu perquè trigaria massa temps. Podeu restringir la selecció mitjançant la cerca (F3) o evitant el mode de visualització plana (F6). Podeu extreure, llistar o verificar directament l'arxiu.
 txt_list_browsing: Navegant per
-txt_archive_root: Browsing: archive's root
-txt_type_description_bzip2: BZip2: quite powerful compression, average speed
-txt_pw_empty: Si us plau, proporciona una contrasenya (o un fitxer de xifratge)
-txt_add_error: Cannot add/update or delete object(s). The archive is not writeable, or cannot support this operation. Editing non-canonical archive types can be enabled in Archive manager options.
+txt_archive_root: Navegant: arrel de l'arxiu
+txt_type_description_bzip2: BZip2: compressió bastant potent, velocitat mitjana
+txt_pw_empty: Si us plau, proporcioneu una contrasenya (o un fitxer de xifratge)
+txt_add_error: No es poden afegir, actualitzar ni suprimir els objectes. L'arxiu no es pot escriure o no admet aquesta operació. L'edició de formats no canònics es pot habilitar a les opcions del Gestor d'arxius.
 txt_un7z_browse_failure: no es pot navegar per l'arxiu
-txt_list_error: Cannot list archive's content, please check if the archive is password protected or corrupted.
-txt_conf_cannotsave: Cannot save configuration file, check if the path is writeable and with some free space
-txt_check_hint: Check for casual data corruption; hash algorithms are suitable to detect even malicious data tampering (see the documentation)
-txt_check: Checksum/hash file(s)
+txt_list_error: No es pot llegir el contingut de l'arxiu. Comproveu si l'arxiu està protegit amb contrasenya o està malmès.
+txt_conf_cannotsave: No es pot desar el fitxer de configuració. Comproveu si la ubicació es pot escriure i disposa d'espai lliure
+txt_check_hint: Comproveu si hi ha danys ocasionals de dades; els algoritmes de hash són adequats per detectar fins i tot manipulacions malicioses de dades (vegeu la documentació)
+txt_check: Suma de comprovació/hash del fitxer
 txt_check_select: Suma de comprovació/hash
 txt_clear: Neteja
 txt_clearlayout: Neteja el resultat
-txt_pj_hint: Click to import task, reset changes and load up to date task definition from GUI
-txt_autoclose: Close PeaLauncher when task completes
+txt_pj_hint: Feu clic per importar la tasca, restablir els canvis i carregar la definició de tasques actualitzada des de la interfície gràfica
+txt_autoclose: Tanca el PeaLauncher quan finalitzi la tasca
 txt_cl: línia de comandes:
 txt_compare: Compara els fitxers
 txt_compress: Comprimeix
@@ -725,33 +725,33 @@ txt_dispaly: Mostra els resultats com a
 txt_displayedmnu_obj: mostrats
 txt_displayedobjects: Objectes mostrats
 txt_nocompress: no comprimeixis
-txt_delete: Vols suprimir definitivament els fitxers seleccionats? L’operació no es pot desfer i els fitxers no es podran recuperar des de la paperera de reciclatge
-txt_wipe: Vols suprimir de forma segura els fitxers seleccionats? L’operació no es pot desfer i els fitxers no es podran recuperar ni amb una aplicació de recuperació de fitxers eliminats
+txt_delete: Voleu eliminar definitivament els fitxers seleccionats? L’operació no es pot desfer i els fitxers no es podran recuperar des de la paperera de reciclatge
+txt_wipe: Voleu eliminar de forma segura els fitxers seleccionats? L’operació no es pot desfer i els fitxers no es podran recuperar ni amb una aplicació de recuperació de fitxers eliminats
 txt_done: Fet
 txt_edit: Edita
 txt_elapsed: transcorregut:
-txt_error_emptycl: Empty command line!
+txt_error_emptycl: Línia d'ordres buida!
 txt_encrypt: Encripta
 txt_encrypted: encriptat
 txt_encryption: Encriptació
-txt_note: Introdueix una nota o descripció
-txt_random_keys: Introdueix claus aleatòries
-txt_random_keys_hint: Introdueix claus aleatòries (no cal que les recordis més endavant)
+txt_note: Introduïu una nota o descripció
+txt_random_keys: Introduïu claus aleatòries
+txt_random_keys_hint: Introduïu claus aleatòries (no cal que les recordeu més endavant)
 txt_ent: Avaluació de l'entropia
-txt_ent_tools: Mou el cursor o utilitza eines addicionals de mostreig d’entropia 
+txt_ent_tools: Moveu el cursor o utilitzeu eines addicionals de mostreig d’entropia 
 txt_eqorlarger: Igual o més gran que el fitxer seleccionat
 txt_eqorrecent: Igual o més recent que el fitxer seleccionat
 txt_eqorolder: Igual o més antic que el fitxer seleccionat
 txt_eqorsmaller: Igual o més petit que el fitxer seleccionat
 txt_equal: Igual que el fitxer seleccionat
 txt_erase_hint: Eliminació segura: sobreescriu amb dades aleatòries, emmascara la mida, reanomena i finalment elimina
-txt_extraction_error: Error extracting the selected object. If the archive is password protected please provide it
-txt_exclude_hint: Exclude file(s), one per line; use * and ? wildcards; " and ' delimiters are not needed
+txt_extraction_error: Error extraient l'objecte seleccionat. Si l'arxiu està protegit amb contrasenya, si us plau, proporcioneu-la.
+txt_exclude_hint: Fitxers a excloure, un per línia. Podeu utilitzar els comodins * i ?. Els delimitadors " i ' no són necessaris
 txt_exclusion_recourse: Filtres d'exclusió amb subdirectoris recursius
 txt_exclusion: Exclou
 txt_exe: Executable
-txt_overwrite_qry: existeix a la ubicació de destinació. Vols substituir els fitxers que s'anomenen igual? (Cancel·la per ometre els fitxers que s'anomenen igual)
-txt_confirm_overwrite: ja existeix. Vols sobreesciure'l? (Clica "No" per ometre'l)
+txt_overwrite_qry: existeix a la ubicació de destinació. Voleu sobreesciure els fitxers que s'anomenen igual? (Cancel·leu per ometre els fitxers que s'anomenen igual)
+txt_confirm_overwrite: ja existeix. Voleu sobreesciure'l? (Feu clic a "No" per ometre'l)
 txt_explore_outpath: Explora la ubicació d'extracció
 txt_explore_path: Explora la ubicació
 txt_ext: Ext:
@@ -790,7 +790,7 @@ txt_list_flat: Vista plana
 txt_unit_floppy: Disquet
 txt_foldername: Nom de la carpeta
 txt_nfolders: Carpetes
-txt_error_input_multi: permet un fitxer únic com a entrada. Pots utilitzar el commutador "Uneix-ho tot en un fitxer TAR abans de comprimir" per desar l'entrada en un arxiu .TAR prèviament, en cas contrari pots triar un altre format. SUGGERIMENT: si selecciones les dades a comprimir abans d'escollir el format de l'arxiu, el commutador "Uneix-ho tot en un fitxer TAR abans de comprimir" es configurarà automàticament
+txt_error_input_multi: permet un fitxer únic com a entrada. Podeu utilitzar el commutador "Uneix-ho tot en un fitxer TAR abans de comprimir" per desar l'entrada en un arxiu .TAR prèviament, en cas contrari podeu escollir un altre format. SUGGERIMENT: si seleccioneu les dades a comprimir abans d'escollir el format de l'arxiu, el commutador "Uneix-ho tot en un fitxer TAR abans de comprimir" es configurarà automàticament
 txt_fwd: Endavant
 txt_list_found: Trobat
 txt_free: Lliure
@@ -811,12 +811,12 @@ txt_type_description_gzip: GZip: compressió més ràpida
 txt_here: aquí
 txt_list_history: Historial
 txt_homeroot: Arrel de l'ordinador o de l'arxiu
-txt_quickbrowse_hint: If browsing is stopped the user can narrow the selection using search or filter functions; extract/list/test functions are not affected in any way.
-txt_backupexe_hint: If something goes wrong and lead to a non functional result, you may recover the original executable from the automatic backup copy
+txt_quickbrowse_hint: Si s'atura la navegació, l'usuari pot restringir la selecció mitjançant funcions de cerca o de filtre; les funcions d'extracció, llistat i verificació no es veuen afectades de cap manera.
+txt_backupexe_hint: Si alguna cosa surt malament i comporta un resultat no funcional, podeu recuperar l'executable original de la còpia de seguretat automàtica
 txt_attach: Si el client de correu admet aquesta ordre, l'arxiu s'adjuntarà a un correu nou
-txt_images: Images
-txt_include_hint: Include file(s), one per line; use * and ? wildcards; " and ' delimiters are not needed
-txt_filters_hint: Inclusion and exclusion filters for 7z binary, please carefully read 7-Zip documentation to understand how those filters works
+txt_images: Imatges
+txt_include_hint: Fitxers a incloure, un per línia. Podeu utilitzar els comodins * i ?. Els delimitadors " i ' no són necessaris
+txt_filters_hint: Filtres d’inclusió i exclusió per al binari 7z. Si us plau, llegiu atentament la documentació de 7-Zip per entendre com funcionen aquests filtres
 txt_inclusion_recourse: Filtres d'inclusió amb subdirectoris recursius
 txt_inclusion: Inclou
 txt_error_function: Funció sol·licitada incorrecta
@@ -830,23 +830,23 @@ txt_iop: entrada, sortida, paràmetres
 txt_ipo: entrada, paràmetres, sortida
 txt_input: entrada:
 txt_integrity: Verifica la integritat
-txt_chunk_size: Mida personalitzada invàlida. Si us plau, corregeix-la a un valor numèric
+txt_chunk_size: Mida personalitzada invàlida. Si us plau, corregiu-la a un valor numèric
 txt_invertsel: Inverteix la selecció
-txt_type_exe: és un executable de Windows, vols executar-lo? (Selecciona "No" per intentar-lo obrir com a arxiu) SUGGERIMENT: alguns executables poden presentar problemes de funcionament si abans no s'extreu la totalitat de l'arxiu
-txt_return_to_archive: està obert actualment. Vols explorar-lo?
+txt_type_exe: és un executable de Windows, voleu executar-lo? (seleccioneu "No" per intentar-lo obrir com a arxiu) SUGGERIMENT: alguns executables poden presentar problemes de funcionament si abans no s'extreu la totalitat de l'arxiu
+txt_return_to_archive: està obert actualment. Voleu explorar-lo?
 txt_not_accessible: ja no és accessible
 txt_type_unsupported: no és un format d'arxiu suportat
 txt_checkname_failed: no és un nom vàlid.
-txt_not_accessible_list: no és accessible. Si us plau, comprova si la llista de fitxers és correcta i està actualitzada
-txt_theme_create_error: It was not possible to create the theme, try to use a name valid for a folder as theme name and to chose a writeable path
-txt_theme_exists: ja existeis. Si us plau, proporciona una ubicació diferent
+txt_not_accessible_list: no és accessible. Si us plau, comproveu si la llista de fitxers és correcta i està actualitzada
+txt_theme_create_error: No ha estat possible crear el tema. Proveu d'utilitzar un nom vàlid per a una carpeta com a nom del tema i triar un camí escrivible
+txt_theme_exists: ja existeix. Si us plau, proporcioneu una ubicació diferent
 txt_job_code: codi de tasca:
 txt_job_definition_saved: La definició de la tasca s'ha desat satisfactòriament a
 txt_job_success: La tasca s'ha completat satisfactòriament!
 txt_join: Uneix
 txt_joinfiles: Uneix fitxers
 txt_keyfile: Fitxer de xifratge
-txt_keyfile_not_found: El fitxer de xifrats no s'ha trobat o no s'ha pogut llegir. Si us plau, selecciona'n un altre
+txt_keyfile_not_found: El fitxer de xifrats no s'ha trobat o no s'ha pogut llegir. Si us plau, seleccioneu-ne un altre
 txt_keyfile_notcreated: No s'ha pogut crear el fitxer de xifratge
 txt_larger: Més gran que el fitxer seleccionat
 txt_lastused: Utilitzat per última vegada
@@ -860,7 +860,7 @@ txt_list_details: Llista (amb detalls)
 txt_list_all: Llista-ho tot
 txt_list_disp: Llista els objectes visibles
 txt_list_sel: Llista els objectes seleccionats
-txt_toggle_warning: Generar la vista plana amb tot el contingut de la ubicació actual pot tardar un cert temps, vols continuar igualment?
+txt_toggle_warning: Generar la vista plana amb tot el contingut de la ubicació actual pot tardar un cert temps, voleu continuar igualment?
 txt_loadfile: Carrega un fitxer
 txt_loadlayout: Carrega una vista
 txt_unit_hd: Disc local
@@ -890,16 +890,16 @@ txt_news: Notícies
 txt_no: No
 txt_noinput: No s'ha rebut cap entrada accessible
 txt_nocompress_hint: sense compressió (més ràpid)
-txt_split_noinput: No s'ha seleccionat cap entrada. Si us plua, selecciona un fitxer a dividir
-txt_open_noinput: No s'ha seleccionat cap entrada. Si us plua, selecciona un arxiu (aquest haurà de ser el primer dels arxius en cas que sigui un conjunt d'arxius multivolum)
+txt_split_noinput: No s'ha seleccionat cap entrada. Si us plau, seleccioneu un fitxer a dividir
+txt_open_noinput: No s'ha seleccionat cap entrada. Si us plau, seleccioneu un arxiu (aquest haurà de ser el primer dels arxius en cas que sigui un conjunt d'arxius multivolum)
 txt_list_nomatch: cap coincidència
 txt_singlethread: Sense processament en paral·lel
 txt_none2: cap
 txt_nonsolid: No-sòlid
 txt_level_normal: Normal
-txt_copy_error: no s'ha copiat o mogut satisfactòriament, codi d'error:
+txt_copy_error: no s'ha copiat o desplaçat satisfactòriament, codi d'error:
 txt_description: Notes
-txt_compare_second: Ara selecciona el fitxer a comparar
+txt_compare_second: Ara seleccioneu el fitxer a comparar
 txt_peaobj: Control d'objectes
 txt_displayed_obj: objecte(s)
 txt_olderthan: Més antic que l'objecte seleccionat
@@ -927,11 +927,11 @@ txt_output: sortida:
 txt_overwrite: Substitueix els fitxers existents
 txt_compressed_size: Empaquetat
 txt_paqver: PAQ version
-txt_type_description_paq: PAQ: slow but extremely powerful compressor
+txt_type_description_paq: PAQ: compressor lent però extremadament potent
 txt_pio: paràmetres, entrada, sortida
 txt_poi: paràmetres, sortida, entrada
 txt_parameters: Paràmetres:
-txt_error_partial: Partial extraction not implemented for current archive type
+txt_error_partial: L'extracció parcial no és compatible amb aquest format d'arxiu
 txt_passes: Passes
 txt_pw: Contrasenya
 txt_pwlength: Longitud de la contrasenya en caràcters (4..64)
@@ -947,14 +947,14 @@ txt_peazip_help: Suport en línia
 txt_peazip_web: Lloc web del PeaZip
 txt_performall: Tots els algoritmes
 txt_name_provide: Els caràcters \ / : * ? ' " < > | no es permeten als noms dels fitxers
-txt_upxorstrip: Si us plau, tanca el Strip i/o l'UPX al binari
-txt_not_removable_file: Si us plau, tanca el fitxer obert per tal que el PeaZip pugui eliminar-lo:
-txt_not_removable: Si us plau, tanca els fitxers oberts per tal que el PeaZip pugui eliminar la carpeta:
-txt_custom_executable_missing: Please provide the custom executable's name
-txt_type_unsupported_select: Si us plau, selecciona un tipus de fitxer suportat:
-txt_no_theme_name: Si us plau, especifica el nom del tema
-txt_please_wait: Si us plau, espera un moment...
-txt_copy_wait: Si us plau, espera que es completin les operacions de còpia i desplaçament de fitxers programades actualment abans de programar altres operacions del mateix tipus
+txt_upxorstrip: Si us plau, tanqueu el Strip i/o l'UPX al binari
+txt_not_removable_file: Si us plau, tanqueu el fitxer obert per tal que el PeaZip pugui eliminar-lo:
+txt_not_removable: Si us plau, tanqueu els fitxers oberts per tal que el PeaZip pugui eliminar la carpeta:
+txt_custom_executable_missing: Si us plau, proporcioneu el nom de l'executable personalitzat
+txt_type_unsupported_select: Si us plau, seleccioneu un tipus de fitxer suportat:
+txt_no_theme_name: Si us plau, especifiqueu el nom del tema
+txt_please_wait: Si us plau, espereu un moment...
+txt_copy_wait: Si us plau, espereu que es completin les operacions de còpia i desplaçament de fitxers programades actualment abans de programar altres operacions del mateix tipus
 txt_previewwith: Previsualitza amb...
 txt_projectadmin: Administrador del projecte:
 txt_type_description_quad: BALZ/QUAD: compressor de fitxers d'alt rendiment basat en ROLZ
@@ -966,11 +966,11 @@ txt_recentarchives: Arxius recents
 txt_rr_hint: Els registres de recuperació permeten intentar corregir arxius en cas de corrupció de dades
 txt_search_refine: Refina els filtres de cerca, accepta els caràcters comodins ? i *
 txt_fefreshf5: Actualitza (F5)
-txt_release: release:
+txt_release: versió:
 txt_unit_removable: Unitat extraïble
-txt_remove_bookmark: Remove bookmark
-txt_remove_external_unit: Remove external device(s)
-txt_removeselected: Remove selected object(s)
+txt_remove_bookmark: Elimina dels preferits
+txt_remove_external_unit: Elimina les unitats extraïbles
+txt_removeselected: Elimina els objectes seleccionats
 txt_rename: Reanomena
 txt_caption_repair: Repara
 txt_restartrequired2: requereix reiniciar l'aplicació per aplicar els canvis
@@ -998,59 +998,59 @@ txt_search_hint: Cerca coincidències amb els filtres als subdirectoris de l'arx
 txt_search_web: Cerca en línia
 txt_list_searching: Cercant...
 txt_securedelete: Eliminació segura
-txt_default_description: Select a function or drag files here
+txt_default_description: Seleccioneu una funció o arrossegueu els fitxers aquí
 txt_selectall: Selecciona-ho tot
 txt_selectdir: Selecciona un directori
 txt_selected_obj: seleccionat
 txt_selected_objects: Objectes seleccionats
 txt_sfx: Autoextraïble
-txt_sendbymail: Envia per e-mail
+txt_sendbymail: Envia per correu electrònic
 txt_set_defaults: Estableix els paràmetres per defecte de l'aplicació
 txt_settings: Configuració
-txt_sfx_interface: sfx interface
+txt_sfx_interface: interfície sfx
 txt_showhints: Mostra els suggeriments
 txt_show_messages: Mostra els missatges informatius
 txt_showpw: Mostra el contigut del camp de la contrasenya
-txt_singlevol: Single volume, do not split
+txt_singlevol: Un sol volum, no es divideix
 txt_size: Mida
 txt_sizeb: Mida (B)
 txt_skip_existing: Omet els fitxers existents
 txt_slowercomp: compressió més lenta però descompressió igual de ràpida
 txt_smaller: Més petit que l'objecte seleccionat
-txt_solid: Solid
+txt_solid: Sòlid
 txt_solid_block: Mida del bloc
-txt_solid_auto: Solid, auto-adjust
-txt_solid_extension: Solid, group by extension
-txt_listtest: sorry, list/test operation is not yet implemented for this format
+txt_solid_auto: Sòlid, ajust automàtic
+txt_solid_extension: Sòlid, agrupa per extensió
+txt_listtest: Ho sentim, les operacions de llistat i verificació encara no s'han implementat per a aquest format
 txt_sortbysel: Ordena segons l'estat de selecció
 txt_list_sorting: Ordenant...
 txt_speed: velocitat
 txt_split: Múltiples parts
-txt_type_description_split: Split a file with optional integrity check
+txt_type_description_split: Dividiu un fitxer i, opcionalment, comproveu-ne la integritat
 txt_split_file: Divideix el fitxer
 txt_list_nostats: no hi ha estadístiques disponibles
 txt_status: Estat
-txt_level_store: Store
+txt_level_store: Emmagatzema
 txt_stream_control: Control de flux
-txt_strip: Strip before UPX (recommended)
+txt_strip: Reemplaça caràcters especials abans de la compressió UPX (recomanat)
 txt_keyfile_created: Fitxer de xifratge creat satisfactòriament com a:
 txt_suggestpw: Crea una contrasenya aleatòria
-txt_noupx: Symbols stripped, UPX compression omitted
+txt_noupx: S'han reemplaçat els símbols, s'ha omès la compressió UPX
 txt_syntax: Sintaxi:
 txt_sysbenchmark: Prova de rendiment del sistema
-txt_benchmark: La prova de rendiment del sistema pot tardar alguns minuts i utilitzarà tota la CPU i memòria disponibles. El sistema pot ser que no respongui durant la prova de rendiment; el vols executar igualment?
+txt_benchmark: La prova de rendiment del sistema pot tardar alguns minuts i utilitzarà tota la CPU i memòria disponibles. El sistema pot ser que no respongui durant la prova de rendiment; el voleu executar igualment?
 txt_systools: Eines del sistema
 txt_tarbefore: Uneix-ho tot en un fitxer TAR abans de comprimir
-txt_type_description_tar: TAR: archiving format mainstream on UNIX systems
+txt_type_description_tar: TAR: format de compressió habitual en sistemes UNIX
 txt_taskman: Administrador de tasques
 txt_caption_test: Verifica
 txt_testall: Verifica-ho tot
 txt_testdisp: Verifica els objectes mostrats
 txt_testpw: Verifica la contrasenya / fitxer de xifratge
 txt_testsel: Verifica els objectes seleccionats
-txt_col_hint: The color should be chosen in order to integrate well with icon colors and to other GUI's elements
-txt_bookmarks_hint: The complete and editable list of bookmarks is available in the file browser interface, clicking on the "More controls" icon and on "Toggle history/bookmarks"
-txt_archive_noinput_tolist: La vista és buida: utilitza "Afegeix fitxers" o "Carrega una vista" per omplir la llista d’arxius
+txt_col_hint: El color s’hauria d’escollir per tal d’integrar-se bé amb els colors de les icones i amb altres elements de la interfície gràfica
+txt_bookmarks_hint: La llista completa i editable de preferits està disponible a la interfície del navegador de fitxers, fent clic a la icona "Més controls" i a "Canvia entre l'historial i els preferits"
+txt_archive_noinput_tolist: La vista és buida: utilitzeu "Afegeix fitxers" o "Carrega una vista" per omplir la llista d’arxius
 txt_theme: Tema
 txt_icons_found: Tema carregat satisfactòriament.
 txt_themename: Nom del tema
@@ -1080,19 +1080,19 @@ txt_type_description_upx: UPX: només comprimeix fitxers executables
 txt_advfilters: Utilitza els filtres avançats
 txt_openfiles_hint: Utilitzeu aquesta opció per incloure a l'arxiu els fitxers oberts des d’altres aplicacions (útil en tasques de còpia de seguretat)
 txt_usenet: Usenet
-txt_user_name: Nom d'usuari; utilitza la forma usuari@DOMINI o DOMINI\usuari si és necessari.
+txt_user_name: Nom d'usuari; utilitzeu la forma usuari@DOMINI o DOMINI\usuari si és necessari.
 txt_using: En ús:
-txt_volumepea: Volume control
+txt_volumepea: Control de volum
 txt_volume_size: Mida del volum
 txt_type_ext_uns: s'ha extret satisfactòriament
 txt_websearch: Cerca en línia
 txt_websites: Pàgines web
-txt_word: Word
+txt_word: Utilització
 txt_write: Escriptura:
-txt_ramdompw_hint: Pots copiar la contrasenya generada aleatòriament des d’aquí
+txt_ramdompw_hint: Podeu copiar la contrasenya generada aleatòriament des d’aquí
 txt_exe_hint: Podeu introduir el nom i els paràmetres d'execució de la compressió personalitzada i escollir la construcció de la sintaxi. Tingueu en compte que també podeu canviar manualment la sintaxi de l'ordre a la pestanya "Consola".
 txt_pj_hint2: Podeu importar la definició de la tasca des de la interfície gràfica d’usuari al camp següent. A continuació, podeu editar-lo, iniciar-lo o desar-lo sense canviar ni perdre la tasca definida per a la interfície gràfica.
-txt_type_description_zip: ZIP: format d'arxivament i compressió ràpid, habitual als sistemes Windows
+txt_type_description_zip: ZIP: format de compressió ràpid, habitual als sistemes Windows
 txt_zipcrypto_hint: ZipCrypto (abandonat)
 
 === end PeaZip text group ===
@@ -1126,28 +1126,28 @@ txt_5_0_from: des de
 txt_5_0_in: dins de
 txt_5_0_to: a
 txt_4_5_search: Cerca
-txt_4_0_drag: Arrossega aquí el fitxer a extreure, o
-txt_4_0_dragorselect: Arrossega'l aquí o selecciona un fitxer
+txt_4_0_drag: Arrossegueu aquí el fitxer a extreure, o
+txt_4_0_dragorselect: Arrossegueu-lo aquí o seleccioneu un fitxer
 txt_4_0_select: selecciona un fitxer
 txt_3_6_selectdir: Selecciona un directori
 txt_3_5_close: Tanca
 txt_3_0_details: Per a més informació, l'"Informe" conté el registre de la tasca i "Consola" conté la definició de la tasca com a seqüència d'ordres.
 txt_3_0_hints: Suggeriments sobre l'error
-txt_3_0_arc: Alguns fitxers d'entrada no s'han pogut llegir (potser estan bloquejats, no són accessibles o estan corromputs, o bé, potser falten alguns volums d'un arxiu multivolum)
+txt_3_0_arc: Alguns fitxers d'entrada no s'han pogut llegir (potser estan bloquejats, no són accessibles o estan malmesos, o bé, potser falten alguns volums d'un arxiu multivolum)
 txt_3_0_ext: L'arxiu deu requerir una contrasenya diferent per executar aquesta operació
 txt_2_8_oop: Obre l'ubicació de sortida quan finalitzi la tasca
 txt_2_7_validatefn: S'ha aturat l’operació, s'ha detectat un nom de fitxer invàlid:
 txt_2_7_validatecl: S'ha aturat l’operació, s'ha detectat una ordre potencialment perillosa (p. ex. ordres concatenades no permeses al programa):
 txt_2_6_open: Obre un arxiu
 txt_2_5_ace_missing: Falta el connector UNACE; per gestionar arxius ACE, podeu descarregar el connector del lloc web del PeaZip (en ser un codi tancat d'UNACE, el connector no es distribueix a,b el paquet base)
-txt_2_3_pw_errorchar_gwrap: les cometes no es poden utilitzar en contrasenyes del PeaLauncher en aquest sistema operatiu, si us plau, canvia la contrasenya o utilitza el mode Consola a Binaris del Backend dins de Opcions > Configuració
+txt_2_3_pw_errorchar_gwrap: les cometes no es poden utilitzar en contrasenyes del PeaLauncher en aquest sistema operatiu, si us plau, canvieu la contrasenya o utilitzeu el mode Consola a Binaris del Backend dins de Opcions > Configuració
 txt_2_3_renameexisting: Reanomena automàticament els fitxers existents
 txt_2_3_renameextracted: Reanomena automàticament els fitxers extrets
 txt_2_3_cancel: Cancel·la
 txt_2_3_encryption: Encriptació
 txt_2_3_extinnew: Extreu-ho en una nova carpeta
 txt_2_3_keyfile: Fitxer de xifratge
-txt_2_3_kf_not_found_gwrap: No s'ha trobat o no s'ha pogut llegir el fitxer de xifratge. Si us plau, escull un fitxer de xifratge diferent.
+txt_2_3_kf_not_found_gwrap: No s'ha trobat o no s'ha pogut llegir el fitxer de xifratge. Si us plau, escolliu un fitxer de xifratge diferent.
 txt_2_3_moreoptions: Més opcions...
 txt_2_3_nopaths: Sense camins
 txt_2_3_options: Opcions
@@ -1157,8 +1157,8 @@ txt_2_3_skipexisting: Salta els fitxers existents
 txt_job_unknown: : S'ha trobat un error desconegut
 txt_stdjob: [l'animació s'aturarà quan es completi la tasca]
 txt_benchmarkjob: [el sistema respondrà lentament mentre s'executi la prova de rendiment del sistema (pot tardar alguns minuts)]
-txt_defragjob: [no respondrà mentre transcorri la desfragmentació, pots executarlo en segon pla]
-txt_consolejob: [pots consultar l'evolució de la tasca a la finestra de la consola]
+txt_defragjob: [no respondrà mentre transcorri la desfragmentació, podeu executar-lo en segon pla]
+txt_consolejob: [podeu consultar l'evolució de la tasca a la finestra de la consola]
 txt_job1: 1: Avís: s'han produït errors lleus; p. ex. no s'han trobat alguns fitxers o estaven bloquejats
 txt_job127: 127: No s'ha pogut executar la operació sol·licitada
 txt_job2: 2: Error fatal
@@ -1202,7 +1202,7 @@ txt_rating: Valoració:
 txt_rt: prioritat en temps real
 txt_report: Informe
 txt_resume: Continua
-txt_priority: Fes clic aquí per establir la prioritat de la tasca
+txt_priority: Feu clic aquí per establir la prioritat de la tasca
 txt_running: En curs,
 txt_isrunning: En curs...
 txt_saveas: Anomena i desa
@@ -1220,17 +1220,17 @@ txt_time: Temps:
 
 === about text group ===
 
-EXTRACT ARCHIVE(S)
-From the system 
-- rightclick on the archive(s) and in system’s context menu click "Extract here" or "Extract here (smart new folder)" to extract with no further interaction. Smart new folder option takes care to create a new top level folder only if necessary, when the archives root contains more than one file or folder.
-- otherwise use "Extract..." menu entry for having more options: output path, password, extract files to a new directory, chose to skip, rename or overwrite existing files etc.
+EXTRACCIÓ D'ARXIUS COMPRIMITS
+Des del sistema
+- Feu clic amb el botó dret sobre l'arxiu o arxius i, al menú contextual del sistema, feu clic a “Extreu aquí” o “Extreu aquí (nova carpeta intel·ligent)” per extreure'ls sense cap interacció addicional. L'opció de “carpeta nova intel·ligent” s'encarrega de crear una nova carpeta només si la ubicació d'extracció ja conté altres fitxers o carpetes.
+- En cas contrari, utilitzeu l'entrada de menú “Extreu ...” per poder escollir més opcions: ubicació de sortida, contrasenya, extracció en un nou directori, omissió de fitxers, canviar el nom o sobreescriure els fitxers existents, etc.
 
-Open an archive in PeaZip, i.e. with doubleclick, or drag an archive on PeaZip’s window or icon
-- click on "Extract" in toolbar or in context menu to extract only selected objects trough the confirmation dialog allowing to set all options (output path, password, naming policy, extract to a new directory etc)
-- drag files and folders to the desired destination, only selected content will be extracted (for more information see chapter about drag and drop in PeaZip)
-- click the quick extraction dropdown button on the right of “Extract” in the toolbar, it allows to directly extract the entire archive to most common destinations (skipping the confirmation dialog) and to set most important options; keyboard shortcuts: Ctrl+E (or F12) extracts the entire archive, asks for output directory; Ctrl+Alt+E extracts archive in its current folder; Ctrl+Shift+E extracts to desktop; Ctrl+Alt+Shift+E extracts to documents; Ctrl+0 extracts to previous path; Ctrl+1..8 extracts to path of bookmark 1..8 (if defined)
+Obriu un arxiu amb el PeaZip, per exemple, fent-li doble clic o arrossegant-lo sobre la finestra o l'icona del PeaZip.
+- Feu clic al botó “Extreu” a la barra superior d'eines o al menú contextual per extreure només els objectes seleccionats mitjançant un quadre de diàleg que us permetrà establir totes les opcions (ubicació de sortida, contrasenya, extracció en un nou directori, omissió de fitxers, canviar el nom o sobreescriure els fitxers existents, etc.)
+- Arrossegueu fitxers i carpetes a la destinació desitjada: només s'extreurà el contingut seleccionat (per obtenir més informació, consulteu el capítol sobre arrossegar i deixar anar del PeaZip)
+- Feu clic al menú ràpid d'extracció situat a la dreta d'“Extreu”, a la barra d'eines. Permet extreure directament l'arxiu sencer a la majoria de destinacions habituals (ometent el quadre de diàleg avançat) i configurar les opcions més importants; Dreceres del teclat: Ctrl+E (o F12) extreu l'arxiu sencer preguntant la ubicació de destí; Ctrl+Alt+E extreu l'arxiu a la seva carpeta actual; Ctrl+Shift+E l'extreu a l'Escriptori; Ctrl+Alt+Shift+E l'extreu als Documents; Ctrl+0 l'extreu a la ubicació anterior; Ctrl+1..8 l'extreu a la ubicació del preferit 1..8 (si s'ha definit prèviament)
 
-Open PeaZip, select one or more archives and click “Extract” in toolbar or context menu, or use quick extraction destinations as explained at the previous point.
+Obre el PeaZip, selecciona un o més arxius i fes clic a “Extreu” a la barra superior d'eines o al menú contextual, o utilitza les destinacions d'extracció ràpides tal i com s'explica en el punt anterior.
 
 EXTRACT ONLY SELECTED OBJECTS FROM THE ARCHIVE
 Open an archive in PeaZip, i.e. with doubleclick, or drag an archive on PeaZip’s window or icon


### PR DESCRIPTION
I translated language files into Catalan. I hope I've done it as expected.

Please review "peazip-sources/res/lang-wincontext/ca.reg" text encoding because it works fine in my computer, but when I upload it to GitHub it seems to be converted, and I can see some wrong characters. I don't know if it's a problem with web browser rendering or a real encoding problem. Any idea?