### PR TITLE
doc: includes sudo for running xattr

### DIFF
--- a/peazip-sources/res/share/readme/readme_macOS.txt
+++ b/peazip-sources/res/share/readme/readme_macOS.txt
@@ -3,7 +3,7 @@ TO INSTALL PEAZIP ON MACOS
 1) Open PeaZip's DMG and drop peazip.app in Applications directory
 2) Open Terminal, paste and run the following command:
 
-xattr -dr com.apple.quarantine /Applications/peazip.app
+sudo xattr -dr com.apple.quarantine /Applications/peazip.app
 
 Running the aforementioned xattr command is needed to remove the "quarantine" attribute which is automatically applied by Safari to unsigned app packages downloaded from the web; otherwise running PeaZip will result in one of the following error messages:
 


### PR DESCRIPTION
Hello there!

Thanks for this awesome App!

While trying to install it on a machine with this MacOSX specs:
![image](https://user-images.githubusercontent.com/16169950/181128984-e5e60fbe-5c14-48db-b5b1-a837b6833d9d.png)

I ran into error messages, event after using `xattr`. It was only after I issued this command with *sudo* that peazip managed to open.

This tiny PR includes `sudo` while running xattr to the docs. 
