### PR TITLE
[Translation] : French translation updated/reworked

### DIFF
--- a/peazip-sources/res/share/lang-wincontext/fr.reg
+++ b/peazip-sources/res/share/lang-wincontext/fr.reg
@@ -1,73 +1,73 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate] 
-@="Ajouter à l'archive"
+@="Ajouter Ã  l'archive"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatesingle]
-@="Ajouter à archive séparée"
+@="Ajouter Ã  des archives sÃ©parÃ©es"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7z]
-@="Ajouter au 7Z"
+@="Ajouter Ã  7Z"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zfastest]
-@="Ajouter au 7Z, rapide"
+@="Ajouter Ã  7Z, rapide"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7znormal]
-@="Ajouter au 7Z, normal"
+@="Ajouter Ã  7Z, normal"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zultra]
-@="Ajouter au 7Z, ultra"
+@="Ajouter Ã  7Z, ultra"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separate7zencrypt]
-@="Encrypt (7Z)"
+@="Crypter (7Z)"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezip]
 @="Ajouter au ZIP"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipfastest]
-@="Ajouter au ZIP, rapide"
+@="Ajouter Ã  ZIP, rapide"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipnormal]
-@="Ajouter au ZIP, normal"
+@="Ajouter Ã  ZIP, normal"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipultra]
-@="Ajouter au ZIP, ultra"
+@="Ajouter Ã  ZIP, ultra"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatezipmail]
-@="Zip/Envoyer par e-mail"
+@="ZIP & Envoyer par e-mail"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2separatesfx]
-@="Ajouter à une archive auto-extractible"
+@="Ajouter Ã  une archive auto-extractible"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2browseasarchive]
-@="Ouvrir comme une archive"
+@="Ouvrir en tant qu'archive"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2browsepath]
-@="Explorer le répertoire avec PeaZip"
+@="Explorer le rÃ©pertoire avec PeaZip"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2split]
-@="Partager le fichier"
+@="Scinder le fichier"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2convert] 
 @="Convertir"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.add2wipe]
-@="Suppression sécurisée"
+@="Suppression sÃ©curisÃ©e"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2here]
 @="Extraire ici"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2smart]
-@="Extraire ici (intelligent)"
+@="Extraire ici (nouveau dossier intelligent)"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2folder]
-@="Extraire ici (dans un nouveau répertoire)"
+@="Extraire ici (nouveau dossier)"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2main]
 @="Extraire..."
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2a]
-@="Extraire archives"
+@="Extraire les archives"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\CommandStore\shell\PeaZip.ext2test]
 @="Tester l(es) archive(s)"

--- a/peazip-sources/res/share/lang/default.txt
+++ b/peazip-sources/res/share/lang/default.txt
@@ -1142,7 +1142,7 @@ txt_type: Type
 txt_level_ultra: Ultra
 txt_error_openfile: Unable to open the specified file
 txt_cl_hint: UNACE and UPX always run using console mode; list, test and benchmark tasks always run using GUI mode
-txt_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin form PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
+txt_ace_missing: UNACE plugin is missing; for handling ACE archives you can download the plugin from PeaZip's website (being UNACE closed source, the plugin is not featured in base package)
 txt_units: units
 txt_unit_unknown: Unknown drive type
 txt_un7z_pw_untested: Untested

--- a/peazip-sources/res/share/lang/fr.txt
+++ b/peazip-sources/res/share/lang/fr.txt
@@ -1,26 +1,26 @@
-﻿=== PeaZip language file ===
-Français
+=== PeaZip language file ===
+Français / French
 9.1
 Traduit par: Drake4478
-Dernière version par: Drake4478
-Date du: 26.02.2023
+Dernière version par: EDM115
+Date du: 12.03.2023
 
 === PeaZip text group ===
 
-txt_9_1_7zs: Niveau de syntaxe 7z/p7zip
-txt_9_1_ac: Les scripts de conversi
-txt_9_1_closeall: Fermer tout
-txt_9_1_enlargeicons: Agrandir les icônes du navigateur de fichiers
-txt_9_1_ef: Exclure les dossiers vides des opérations d’archivage et d’extraction (7z/p7zip)
+txt_9_1_7zs: Niveau de syntaxe 7z / p7zip
+txt_9_1_ac: Les scripts de conversion d'archive autorisent l'interaction utilisateur
+txt_9_1_closeall: Tout fermer
+txt_9_1_enlargeicons: Agrandir les icônes de l'explorateur de fichiers
+txt_9_1_ef: Exclure les dossiers vides des opérations d'archivage et d'extraction (7z / p7zip)
 txt_9_1_nw: Ouvrir dans une nouvelle fenêtre
-txt_9_1_qdup: Utiliser une routine de déduplication rapide
-txt_9_0_autoexttar: Extraction automatique de l’archive TAR à partir de fichiers TAR.* compressés
-txt_9_0_accesstime: Ne pas modifier l’heure du dernier accès
+txt_9_1_qdup: Utiliser la routine de déduplication rapide
+txt_9_0_autoexttar: Extraction automatique de l’archive TAR à partir de fichiers compressés TAR.*
+txt_9_0_accesstime: Ne pas modifier la date du dernier accès
 txt_9_0_mem: Utilisation maximale de la mémoire
 txt_9_0_showmainmenu: Ouvrir le menu principal
 txt_9_0_navmenu: Ouvrir le menu de navigation
 txt_9_0_plugind: Ouvrir les binaires et le répertoire des plugins
-txt_9_0_df: Trier les dirs avant les fichiers
+txt_9_0_df: Trier les dossiers avant les fichiers
 txt_9_0_hl: Stocker des liens physiques sous forme de liens
 txt_9_0_sl: Stocker des liens symboliques sous forme de liens
 txt_9_0_tnav: Basculer la barre latérale, arborescence, aucune
@@ -33,14 +33,14 @@ txt_8_8_ca: Couleur d’accentuation
 txt_8_8_btn: Bouton
 txt_8_8_cb: Couleur du bouton
 txt_8_8_centered: Boutons centrés
-txt_8_8_light: Lumière
+txt_8_8_light: Clair
 txt_8_8_lnk: Lien
-txt_8_8_intnote: Veuillez noter que l'option "Extraction interactive" (dans Options > Paramètres > Gestionnaire d’archives) est ignoré pour la composition de la ligne de commande dans l’onglet console.
+txt_8_8_intnote: Veuillez noter que l'option "Extraction interactive" (dans Options > Paramètres > Gestionnaire d’archives) est ignorée pour la composition de la ligne de commande dans l’onglet Console.
 txt_8_8_snz: Propager le flux Zone.Identifier (Windows)
-txt_8_8_sm: Petite taille des icônes
-txt_8_8_solcol: Barre pleine
-txt_8_8_snoi: ID du propriétaire/groupe du magasin (TAR, Linux)
-txt_8_8_snon: Noms des propriétaires/groupes de magasins (TAR, Linux)
+txt_8_8_sm: Icônes de petite taille
+txt_8_8_solcol: Barre d'adresse
+txt_8_8_snoi: Stocker l'ID du propriétaire/groupe (TAR, Linux)
+txt_8_8_snon: Stocker les noms des propriétaires/groupes (TAR, Linux)
 txt_8_8_tab: Onglet
 txt_8_8_altt: Style d’onglets
 txt_8_8_autotest: Tester les archives après la création, si elles sont prises en charge par le format
@@ -49,19 +49,19 @@ txt_8_7_csvhelp: "," norme internationale, ";" commun dans les paramètres régi
 txt_8_7_after: Après archivage / extraction
 txt_8_7_bintest: binaires testés.
 txt_8_7_csv: Séparateur CSV
-txt_8_7_hok: Hachage des binaires utilisés par PeaZip correspondance avec les valeurs attendues
+txt_8_7_hok: Le hachage des binaires utilisés par PeaZip correspond aux valeurs attendues
 txt_8_7_mo: Définir les options du gestionnaire d’archives
 txt_8_7_showhm: Afficher le menu d'en-tête du navigateur de fichiers
 txt_8_7_showsearchbar: Afficher la barre de recherche
-txt_8_7_showsm: Afficher le menu style
+txt_8_7_showsm: Afficher le menu Style
 txt_8_7_hnotok: Certains hachages de binaires utilisés par PeaZip ne correspondent pas aux valeurs attendues:
 txt_8_7_verifybin: Vérifier le hachage des fichiers binaires
-txt_8_6_clear: "Transparent" supprime les fichiers modifiés temporairement, sinon disponibles pour une modification ultérieure.
+txt_8_6_clear: L'option "Effacer" supprime les fichiers modifiés temporairement, sinon ils seront disponibles pour une modification ultérieure.
 txt_8_6_noclear: Ignorer toutes les modifications sans mettre à jour l’archive
 txt_8_6_nosimple: Ne pas mettre à jour l’archive, conserver les fichiers modifiés temporairement pour d’autres modifications
 txt_8_6_immediate: Exécution immédiate
 txt_8_6_yessimple: Mettre à jour l’archive, conserver les fichiers modifiés temporairement pour une modification ultérieure
-txt_8_5_advbrowser: Appliquer des filtres au navigateur d’archivage
+txt_8_5_advbrowser: Appliquer des filtres à l'explorateur d'archives
 txt_8_5_detailslarge: Détails, grand
 txt_8_5_intext: Extraire vers le chemin de travail temporaire puis passer à la sortie (demander avant d’écraser)
 txt_8_5_listlarge: Liste, grande
@@ -82,7 +82,7 @@ txt_8_3_noupx: Ce binaire ne peut pas être compressé (peut être déjà compre
 txt_8_2_slower: (lent)
 txt_8_2_df: 7z / p7zip afficher le contenu des dossiers
 txt_8_2_vreport: 7z / p7zip rapport non verbeux
-txt_8_2_ta: Consultée
+txt_8_2_ta: Consulté
 txt_8_2_tc: Créé
 txt_8_2_keep: Conserver les fichiers
 txt_8_2_tm: Modifié
@@ -91,29 +91,29 @@ txt_8_2_alltimes: Stocker tous les horodatages
 txt_8_2_supportedby: Supporté par
 txt_8_1_preparse: Toujours pré-analyser les archives
 txt_8_1_bo: Optimisation du navigateur
-txt_8_1_bop: Les options d’optimisation du navigateur peuvent être définies à partir des options > paramètres, onglet Général, afin de permettre au navigateur d’afficher des archives contenant un très grand nombre d’éléments.
+txt_8_1_bop: Les options d’optimisation du navigateur peuvent être définies à partir des Options > Paramètres, onglet Général, afin de permettre au navigateur d’afficher des archives contenant un très grand nombre d’éléments.
 txt_8_1_nopreparse: Ne pas pré-analyser les archives
 txt_8_1_ed: erreur(s) détectée(s).
-txt_8_1_togglearc: La liste des vues plates du contenu des archives peut prendre beaucoup de temps, continuez quand même ?
+txt_8_1_togglearc: L'affichage à plat du contenu de l'archive peut prendre du temps, continuer quand même ?
 txt_8_1_preparsehint: Optimiser les performances en limitant la pré-analyse des grandes archives. La pré-analyse est destinée à détecter à l’avance les éventuels problèmes dans le contenu de l’archive.
 txt_8_1_slow: Lent
 txt_8_1_vslow: Très lent
-txt_8_1_volumes: Volumes
-txt_8_0_altcol: Autre couleur de grille
-txt_8_0_forcebrowse: Parcourir les types d’archives non canoniques (conteneurs, images disque, programmes d’installation,...)
+txt_8_1_volumes: volumes
+txt_8_0_altcol: Autre grille de couleur
+txt_8_0_forcebrowse: Parcourir les types d’archives non canoniques (conteneurs, images disque, programmes d’installation, ...)
 txt_8_0_commonalgo: Algorithmes courants
 txt_8_0_forceconvert: Convertir des types d’archives non canoniques
-txt_8_0_defaultactionhint: Action par défaut double-cliquant sur un fichier associé à PeaZip à partir du système
+txt_8_0_defaultactionhint: Action par défaut en double-cliquant sur un fichier associé à PeaZip depuis le système
 txt_8_0_defaultaction: Action par défaut au démarrage
 txt_8_0_enableextand: Activer le sous-menu "Extraire et ouvrir avec"
 txt_8_0_forcetyping: Forcer la saisie interactive des mots de passe
 txt_8_0_setpwopt: Définir les options du mot de passe/fichier de clé
 txt_8_0_forcetypinghelp: Exécutera les fichiers binaires principaux dans la console, ne peut pas parcourir les archives avec des noms de fichiers chiffrés. Permet de créer des scripts qui ne s’exécuteront pas sans assistance, mais demanderont plutôt à l’utilisateur de manière interactive un mot de passe.
 txt_7_9_spacing: Espacement
-txt_7_9_zooming: Zoomer
+txt_7_9_zooming: Zoom
 txt_7_8_changelocalization: Changer la langue de PeaZip
 txt_7_8_custext: Extension personnalisée
-txt_7_8_destexistfile: Destination contient déjà des fichiers traités. Remplacer les fichiers par le même nom ?
+txt_7_8_destexistfile: Destination contient déjà des fichiers traités. Remplacer les fichiers du même nom ?
 txt_7_8_dd: Glisser/déposer
 txt_7_8_priorityhigh: Élevé
 txt_7_8_priorityidle: Inactif
@@ -123,22 +123,22 @@ txt_7_8_priorityrealtime: Temps réel
 txt_7_8_requirerestart: [nécessite le redémarrage de PeaZip]
 txt_7_8_tpriority: Priorité des tâches
 txt_7_8_update: Mise à jour
-txt_7_7_noneall: Aucun (pas d'aperçu, pas d'extraction par glisser-déposer)
-txt_7_7_nonetemp: Aucun, température de l'utilisateur si nécessaire
-txt_7_7_outtemp: Sortie, aperçu dans la température de l'utilisateur
+txt_7_7_noneall: Aucun (pas d'aperçu, pas de modification, pas d'extraction par glisser-déposer, pas d'extraction interactive)
+txt_7_7_nonetemp: Aucun, dossier temporaire de l'utilisateur si nécessaire
+txt_7_7_outtemp: Sortie, aperçu dans le dossier temporaire de l'utilisateur
 txt_7_7_sys7zreq: Nécessite l'installation de p7zip-full ou équivalent
 txt_7_7_tw: Dossier de travail temporaire pour la création d'archives, l'édition, l'aperçu et l'extraction par glisser-déposer.
-txt_7_7_sys7z: Utiliser le système 7z sous Linux
-txt_7_6_zipenc: Encodage des noms de fichiers 7z/p7zip ZIP
+txt_7_7_sys7z: Utiliser le système 7z sous Linux si disponible
+txt_7_6_zipenc: Encodage des noms de fichiers 7z / p7zip ZIP
 txt_7_6_color: Couleur
 txt_7_6_custenc: Page de code personnalisée
 txt_7_6_dark: Sombre
 txt_7_6_tno: Ne synchronisez pas l’arbre d’archives
-txt_7_6_forcelocalenc: Force locale
-txt_7_6_forceutf8enc: Force UTF-8
-txt_7_6_cpnote: Si la page de code personnalisée choisie n’est pas pris en charge, les tâches se termineront toujours par erreur (erreur d’allocation de mémoire très probable). Dans le cas où cela se produit, modifier la page de code ou réinitialiser l’application.
+txt_7_6_forcelocalenc: Forcer local
+txt_7_6_forceutf8enc: Forcer UTF-8
+txt_7_6_cpnote: Si la page de code personnalisée choisie n’est pas prise en charge, les tâches se termineront toujours par erreur (très probablement une erreur d’allocation de mémoire). Dans le cas où cela se produit, modifiez la page de code ou réinitialisez l’application.
 txt_7_6_defaultenc: Local, UTF-8 pour les symboles supplémentaires
-txt_7_6_dim: Faible lumière
+txt_7_6_dim: Ombré
 txt_7_6_setcurdef: Définir le chemin actuel comme chemin de sortie par défaut
 txt_7_6_setdef: Définir le chemin de sortie par défaut
 txt_7_6_tadvanced: Synchroniser l'arborescence des archives, conserver les nœuds visités
@@ -148,10 +148,10 @@ txt_7_5_always: Toujours
 txt_7_5_ask: Demander
 txt_7_5_autoclosesingle: Fermeture automatique après extraction si aucune action de navigation n’a eu lieu
 txt_7_5_cutlen: Couper le nom à la longueur spécifiée
-txt_7_5_cutlenw: Couper le nom à la longueur spécifiée (4..255) les conflits de dénomination peuvent être corrigés manuellement ultérieurement
+txt_7_5_cutlenw: Couper le nom à la longueur spécifiée (4..255) les conflits de nommage peuvent être corrigés manuellement ultérieurement
 txt_7_5_dragnone: Ne verrouillez pas la cible
 txt_7_5_specialbrowse: Voulez-vous tout extraire afin de fournir au fichier les données supplémentaires dont il peut avoir besoin ?
-txt_7_5_ee: Extraire tout pour les types de fichiers spéciaux
+txt_7_5_ee: Tout extraire pour les types de fichiers spéciaux
 txt_7_5_draghide: Cacher la cible de dépôt
 txt_7_5_draglh: Verrouiller et cacher la cible
 txt_7_5_draglock: Verrouiller la cible de dépôt
@@ -162,24 +162,24 @@ txt_7_4_7zfbrotlicomp: Compression la plus rapide, 7Z Brotli
 txt_7_4_7zfzstandardcomp: Compression la plus rapide, 7Z Zstandard
 txt_7_4_presetrar: Haute compression, RAR
 txt_7_4_tkeep: Conserver l’horodatage d’archive d’origine
-txt_7_4_lock: Archive de verrouillage
+txt_7_4_lock: Verouiller l'archive
 txt_7_4_locked: verrouillé
-txt_7_4_lockconfirm: Les archives verrouillées ne peuvent pas être modifiées davantage, procéder à la verrouillage de cette archive ?
-txt_7_4_recover: Archive de réparation
+txt_7_4_lockconfirm: Les archives verrouillées ne peuvent plus être modifiées, continuer à verrouiller cette archive ?
+txt_7_4_recover: Réparer l'archive
 txt_7_4_tcurr: Définir l’horodatage d’archive à partir de l’heure actuelle du système
 txt_7_4_setarc: Définir les options d’archivage
 txt_7_4_setext: Définir les options d’extraction
 txt_7_4_swzipx: Passer à l’extension zipx pour les archives zip non-Deflate
 txt_7_3_archiveerrors: [l'archive peut contenir des erreurs]
-txt_7_3_archiveerrorshint: Les archives peuvent ne pas être valides (en raison de données manquantes, corrompues ou hors de données standard), il est possible d’exécuter Test pour des informations détaillées. Si la table de contenu de l’archive est cryptée, un mot de passe est nécessaire avant de le parcourir.
-txt_7_3_clickextall: Cliquez sur "Extraire tout" pour activer
-txt_7_3_noconfdel: Ne demandez pas confirmation pour supprimer après l’archivage/extraction
+txt_7_3_archiveerrorshint: L'archive peut ne pas être valide (en raison de données manquantes, corrompues ou hors des standards), il est possible de lancer un Test pour des informations détaillées. Si la table de contenu de l’archive est cryptée, un mot de passe est nécessaire avant de la parcourir.
+txt_7_3_clickextall: Cliquez sur "Tout extraire" pour activer
+txt_7_3_noconfdel: Ne pas demander de confirmation pour supprimer après l’archivage/extraction
 txt_7_3_profile7zfastest: Compression rapide, 7Z le plus rapide
 txt_7_3_maxbr: Maximisez la compression Brotli en utilisant plus de mémoire (peut être incompatible avec certains extracteurs)
 txt_7_3_maxzstd: Maximiser la compression Zstandard en utilisant plus de mémoire
 txt_7_3_profile7zfast: Compression moyenne, 7z rapide
 txt_7_3_stl: Définir l'horodatage de l'archive à partir du fichier le plus récent
-txt_7_2_altcomp: Compression alternative, ARC
+txt_7_2_altcomp: Haute compression, ARC
 txt_7_2_clearnoupdate: Effacer les fichiers modifiés
 txt_7_2_autoclosepeazip: Fermer PeaZip lorsque la tâche se termine
 txt_7_2_zpaqall: Extraire toutes les révisions
@@ -190,45 +190,45 @@ txt_7_2_fzstandardcomp: Compression la plus rapide, Zstandard
 txt_7_2_loadcompsettings: Charger les paramètres de compression
 txt_7_2_savecompsettings: Enregistrer les paramètres de compression
 txt_7_2_source: Source
-txt_7_2_updateclear: Mettre à jour les fichiers modifiés dans les archives et effacer les fichiers modifiés
+txt_7_2_updateclear: Mettre à jour les fichiers modifiés dans l'archive et effacer les fichiers modifiés
 txt_7_1_type_description_brotli: Brotli: compresseur rapide de Google, décompression très rapide
-txt_7_1_new: Extraire tous ici, dans le nouveau dossier
-txt_7_1_smart: Extraire tout ici, intelligent
+txt_7_1_new: Tout extraire ici, nouveau dossier
+txt_7_1_smart: Tout extraire ici, nouveau dossier intelligent
 txt_7_1_profileintermediate: Compression intermédiaire, ZIP/BZip2 rapide
 txt_7_1_renfilesonly: Renommer uniquement les fichiers
-txt_7_1_typetosearch: Type à rechercher dans le chemin actuel
+txt_7_1_typetosearch: Écrire pour rechercher dans le chemin actuel
 txt_7_1_type_description_zstd: Zstandard: compresseur rapide de Facebook, décompression très rapide
 txt_7_0_af: Analyser le contenu des dossiers
-txt_7_0_autoopentar: Auto seule archive tar ouvert à l'intérieur tar.* fichiers
+txt_7_0_autoopentar: Ouverture automatique de l'archive TAR dans les fichiers TAR.* compressés
 txt_7_0_exttmppath: Le contenu sera extrait en dehors du chemin de travail temporaire, dans: 
 txt_6_9_autou: Mise à jour automatique des fichiers modifiés dans les archives
-txt_6_9_forceu: Force mise à jour des fichiers modifiés dans les archives
+txt_6_9_forceu: Forcer la mise à jour des fichiers modifiés dans les archives
 txt_6_9_opuns: Opération non prise en charge pour le type d'archive actuel
-txt_6_9_overarch: Remplacer le(s) fichier(s) avec le même nom déjà existant à l'intérieur de l'archive ?
-txt_6_9_uconf: Le fichier prévisualisé a été modifié. Mise à jour des archives actuelles ?
+txt_6_9_overarch: Remplacer le(s) fichier(s) avec le même nom déjà existant(s) à l'intérieur de l'archive ?
+txt_6_9_uconf: Le fichier prévisualisé a été modifié. Mise à jour de l'archive actuelle ?
 txt_6_8_ndrop: Utiliser le glisser-déposer natif sur Windows
 txt_6_7_nop: (pas de prévisualisation)
-txt_6_6_pdupfound doublons possibles trouvés (test approximatif rapide)
+txt_6_6_pdupfound: doublons possiblement trouvés (test approximatif rapide)
 txt_6_6_rsh: Réinitialiser l'historique des recherches
 txt_6_6_pdupfind: Suggérer des doublons possibles
 txt_6_6_forcemodify: Essayez de modifier des types de fichiers non pris en charge explicitement
 txt_6_5_mandatory: (obligatoire)
-txt_6_5_abort: Abandonner
+txt_6_5_abort: Arrêter
 txt_6_5_askp: Demander de définir le mot de passe au démarrage
 txt_6_5_chp: Modifier le mot de passe
-txt_6_5_def: Definition
+txt_6_5_def: Définition
 txt_6_5_nop: Ne pas demander de définir le mot de passe au démarrage
 txt_6_5_error: Erreur
-txt_6_5_seqerr: Erreur(s) détectée, les fichiers originaux ne seront pas supprimés
+txt_6_5_seqerr: Erreur(s) détectée(s), les fichiers originaux ne seront pas supprimés
 txt_6_5_sni: Inclure les informations de sécurité NT
-txt_6_5_sns: Inclure NTFS flux de données alternatives
-txt_6_5_privacy: Privée
-txt_6_5_showvolatile: Show which options are volatile/context depentent
-txt_6_5_force: Essayez d'ouvrir les archives contenant des erreurs
+txt_6_5_sns: Inclure les flux de données NTFS alternatifs
+txt_6_5_privacy: Confidentialité
+txt_6_5_showvolatile: Montrer quelles options sont volatiles / dépendantes du contexte
+txt_6_5_force: Essayer d'ouvrir les archives contenant des erreurs
 txt_6_5_warning: Attention
 txt_6_5_yes: Oui
-txt_6_5_yesall: Oui à tous
-txt_6_5_np: Vous pouvez maintenant changer le mot de passe de(s) archive(s) converties en une nouvelle, ou vider le mot de passe pour passer le cryptage
+txt_6_5_yesall: Oui à tout
+txt_6_5_np: Vous pouvez maintenant changer le mot de passe de(s) archive(s) converties en une nouvelle, ou effacer le mot de passe pour ignorer le cryptage
 txt_6_4_absolute: Chemins absolus
 txt_6_4_appdirn: Ajouter le nom de répertoire
 txt_6_4_closeallother: Fermer tous les autres onglets
@@ -242,107 +242,107 @@ txt_6_4_paths: Chemins
 txt_6_4_prepdirn: Faire précéder le nom du répertoire
 txt_6_4_relative: Chemins relatifs
 txt_6_4_tabbar: Barre d'onglets
-txt_6_3_autoadjust: Colonnes d'ajustement automatique
+txt_6_3_autoadjust: Ajustement automatique des colonnes
 txt_6_3_cinfo: Infos et commentaires
-txt_6_3_syn: Synchroniser l’archive avec disque
-txt_6_3_uar: Mise à jour uniquement les fichiers déjà en archives
+txt_6_3_syn: Synchroniser l’archive avec le disque
+txt_6_3_uar: Mise à jour uniquement les fichiers déjà dans l'archive
 txt_6_2_encext: Ajouter le suffixe ".enc" aux archives cryptées
 txt_6_2_archive: Type de fichier d’archive
 txt_6_2_container: Type de fichier conteneur
 txt_6_1_ec: Développer/réduire l’arborescence de l’archive
 txt_6_0_msq: Trier par type de fichier pour la compression solide
 txt_5_9_lff: Analyser les fichiers et dossiers
-txt_5_9_pff: Analyser, Afficher les fichiers d'en-tête/EOF
-txt_5_9_start: Démarrer à partir
+txt_5_9_pff: Analyser, afficher les fichiers d'en-tête/EOF
+txt_5_9_start: Démarrer à partir de
 txt_5_8_l0: Autoriser tout composant/format pris en charge
 txt_5_8_l1: Autoriser uniquement les composants de logiciels libres
-txt_5_8_l2: Autoriser uniquement ouvrir formats d'archives
+txt_5_8_l2: Autoriser uniquement les formats d'archive ouverts
 txt_5_8_ascii: ASCII sécuritaire, les scripts sont sans danger sur des environnements hérités
-txt_5_8_cp: Page de code sécurisé, scripts peuvent déclencher des problèmes sur des environnements hérités avec des pages de code différentes
+txt_5_8_cp: Page de code sécurisé, les scripts peuvent déclencher des problèmes sur des environnements hérités avec des pages de code différentes
 txt_5_8_fs: Conformité de logiciel libre
-txt_5_8_utf: Scripts besoin de plein UTF-8/Unicode environnement
-txt_5_8_fsr: Ce format est pas suported en raison des restrictions de conformité de logiciels libres (Options > Avancée)
+txt_5_8_utf: Les scripts nécessitent un environnement UTF-8/Unicode complet
+txt_5_8_fsr: Ce format est pas suported en raison des restrictions de conformité de logiciels libres (Options > Avancé)
 txt_5_7_pinstalled: INSTALLÉ
 txt_5_7_pmissing: MANQUANT
-txt_5_7_plugin: Plugin manquant, peut être installé à partir d'Aide-> Rechercher les pulgin et addon
-txt_5_6_basic: Base
+txt_5_7_plugin: Plugin manquant, peut être installé à partir d'Aide > Rechercher les plugins et addons
+txt_5_6_basic: Basique
 txt_5_6_exarc: Extraire l'archive
 txt_5_6_tab: Ouvrir dans un nouvel onglet
 txt_5_6_rc: Faites un clic droit pour les options
-txt_5_6_layouts: Les mises en page sont enregistrés
-txt_5_6_upexisting: Mise à jour des archives existantes
+txt_5_6_layouts: Dispositions enregistrées
+txt_5_6_upexisting: Mettre à jour l'archive existante
 txt_5_6_verbose: Verbeux
 txt_5_5_case: (sensible à la casse)
 txt_5_5_add: Ajouter la chaîne à la position spécifiée
 txt_5_5_addsel: Ajouter à la sélection actuelle
 txt_5_5_ext: Changer l'extension des fichiers
-txt_5_5_plugin: Cocher pour plugin et addon
-txt_5_5_copypath: Chemin de la copie
+txt_5_5_plugin: Plugin/Addon PeaZip
+txt_5_5_copypath: Copier le chemin
 txt_5_5_delete: Supprimer des caractères à la position spécifiée
 txt_5_5_halt: Arrêter le système lorsque la tâche est terminée
-txt_5_5_positionw: Astuce: 1 Ajouter avant le premier char, 2 secondes, etc... "z" pour le nom de la fin du fichier
-txt_5_5_positionwd: Astuce: 1 supprimez du premier char inclus, 2 secondes... "z" pour le nom de la fin du fichier
-txt_5_5_replaceneww: Astuce: fournir une chaîne de nouveau vide pour supprimer simplement la corde usagée
-txt_5_5_lower: Minuscules
-txt_5_5_replaceoldw: Modifier toutes les occurrences de cette chaîne ou un caractère dans le nom du fichier
+txt_5_5_positionw: Astuce: 1 Ajouter avant le premier caractère, 2 avant le second, etc... "z" pour la fin du nom de fichier
+txt_5_5_positionwd: Astuce: 1 supprimez le premier caractère inclus, 2 ssupprimer le second, ... "z" pour la fin du nom de fichier
+txt_5_5_replaceneww: Astuce : fournissez une nouvelle chaîne vide pour simplement supprimer l'ancienne chaîne
+txt_5_5_lower: minuscules
+txt_5_5_replaceoldw: Modifier toutes les occurrences de cette chaîne/caractère dans le nom du fichier
 txt_5_5_newext: Nouvelle extension
 txt_5_5_new: Nouvelle chaîne
 txt_5_5_n: Nombre de caractères à supprimer
-txt_5_5_old: Chaîne usagée
-txt_5_5_position: Position (n° ou "z" à la fin)
-txt_5_5_intdir: Supprimer le répertoire intermédiaire unique sur extrait de nouvelles opérations de dossier
-txt_5_5_replacestr: Remplacer/supprimer chaîne
-txt_5_5_datesameday: Jour même de l'objet sélectionné
+txt_5_5_old: Ancienne chaîne
+txt_5_5_position: Position (n° ou "z" pour la fin)
+txt_5_5_intdir: Nouveau dossier intelligent
+txt_5_5_replacestr: Remplacer/supprimer la chaîne
+txt_5_5_datesameday: Même jour de l'objet sélectionné
 txt_5_5_datesamehour: Même l'heure de l'objet sélectionné
 txt_5_5_datesamemonth: Même mois de l'objet sélectionné
-txt_5_5_datesameweek: Semaine même de l'objet sélectionné
-txt_5_5_datesameyear: La même année de l'objet sélectionné
+txt_5_5_datesameweek: Même semaine de l'objet sélectionné
+txt_5_5_datesameyear: Même année de l'objet sélectionné
 txt_5_5_scan: Analyser
-txt_5_5_select: Sélectionné
-txt_5_5_similar: Semblable à l'objet sélectionné
+txt_5_5_select: Sélectionner
+txt_5_5_similar: Similaire à l'objet sélectionné
 txt_5_5_starting: Commençant par le même caractère
 txt_5_5_string: Chaîne à ajouter
-txt_5_5_subtractsel: Soustraire de la sélection en cours
+txt_5_5_subtractsel: Enlever de la sélection en cours
 txt_5_5_datehour: Cette heure
 txt_5_5_datemonth: Ce mois-ci
 txt_5_5_dateweek: Cette semaine
 txt_5_5_dateyear: Cette année
 txt_5_5_dateday: Aujourd'hui
-txt_5_5_upper: Majuscules
-txt_5_5_extw: Attention: changer l'extension de fichier du fichier peut devenir inutilisable
-txt_5_4_da: Ajouter une date
+txt_5_5_upper: MAJUSCULES
+txt_5_5_extw: Attention: changer l'extension du fichier peut le rendre inutilisable
+txt_5_4_da: Date ajoutée
 txt_5_4_deletearchives: Supprimer les archives après extraction
 txt_5_4_deletefiles: Supprimer les fichiers après archivage
-txt_5_4_deleteoriginal: Procédure de suppression, comme indiqué dans l'écran principal, est ajoutée au script.
+txt_5_4_deleteoriginal: La procédure de suppression, telle que définie dans l'écran principal, sera ajoutée au script.
 txt_5_4_lv: Dernière visite
 txt_5_4_deletearchivesconfirm: Confirmer la suppression des archives originales ?
 txt_5_4_deletefilesconfirm: Confirmer la suppression de fichiers d'origine ?
 txt_5_4_used: Utilisé
-txt_5__3_profilebest: Meilleure compression, format 7z niveau Ultra
-txt_5_3_profileadvanced: Compression avancée, le format 7z
-txt_5_3_profilenormal: Compression Zip normal, compatible avec la plupart des extracteurs
-txt_5_3_profileveryfast: Compression Zip très rapide, recommandée pour les fichiers multimédias volumineux
-txt_5_3_profilepassword: Protéger par mot de passe, le format 7z
-txt_5_3_profile10mb: Garder la sortie moins de 10 Mo, pour les limitations de pièce jointe de courrier
-txt_5_3_profilesfx: Auto extraction, bénéficiaires n'auront pas un logiciel d'extraction
-txt_5_3_cml: Langue du menu contexte système
-txt_5_3_cmlmessage: Cliquez deux fois sur la langue du menu contexte souhaité et confirmez le registre fusion. Ce paramètre doit être réappliqué lorsque l'application est installé/mis à jour ou après avoir utilisé l'Assistant intégration système.
-txt_5_3_exc: Filtres d'exclusion prévalent sur les filtres de l'inclusion
+txt_5__3_profilebest: Compression extrême, 7z ultra
+txt_5_3_profileadvanced: Haute compression, 7z
+txt_5_3_profilenormal: Compression ZIP normale, compatible avec la plupart des extracteurs
+txt_5_3_profileveryfast: Compression ZIP rapide, compatible avec la plupart des extracteurs
+txt_5_3_profilepassword: Protéger par mot de passe, 7z
+txt_5_3_profile10mb: Gardez la sortie sous 25 Mo, pour les limitations des pièces jointes aux e-mails
+txt_5_3_profilesfx: Extraction automatique, le destinataire n'aura pas besoin d'un logiciel d'extraction
+txt_5_3_cml: Langue du menu contextuel du système
+txt_5_3_cmlmessage: Double-cliquez sur la langue du menu contextuel souhaitée et confirmez la fusion du registre. Ce paramètre doit être réappliqué lorsque l'application est installée/mise à jour ou après l'utilisation de l'assistant d'intégration système.
+txt_5_3_exc: Les filtres d'exclusion prévalent sur les filtres d'inclusion
 txt_5_3_ia: Inclure également
 txt_5_3_io: Inclure uniquement
 txt_5_3_rec: Sous-répertoires de façon récursive
-txt_5_3_resetsi: Re-configurer l'intégration de système (associations de fichier menu, SendTo, contexte) ?
-txt_5_2_oadd: Archiver sur le doosier d'origine
-txt_5_2_zerodelete: Vous voulez supprimer et remplacer par tous les fichiers sélectionnés 0 ? L'opération ne peut pas être annulée et les fichiers ne seront pas récupérables
-txt_5_2_zfree: Vous voulez écraser avec tout l'espace libre 0 sur ce lecteur ?
+txt_5_3_resetsi: Re-configurer l'intégration système (associations de fichier, Envoyer vers, menu contextuel) ?
+txt_5_2_oadd: Archiver dans le chemin d'origine
+txt_5_2_zerodelete: Voulez-vous supprimer et écraser avec des 0 les fichiers sélectionnés ? L'opération ne peut pas être annulée et les fichiers ne seront pas récupérables
+txt_5_2_zfree: Vous voulez écraser avec des 0 tout l'espace libre sur ce lecteur ?
 txt_5_2_sdfree: Vous voulez supprimer en toute sécurité l'espace libre sur ce disque ?
-txt_5_2_oext: Extrait dans le doosier d'origine
-txt_5_2_securedeletefree: Sécuriser l'espace libre de supprimer
-txt_5_2_free: Cette opération peut prendre quelques minutes et, si souvent, il peut porter rapidement basé sur flash disques
-txt_5_2_zerofiles: Zéro suppression
-txt_5_2_zerofree: Zéro supprimer espace libre
-txt_5_1_schedadd: Ajouter annexe
-txt_5_1_schederr: Impossible de créer le calendrier
+txt_5_2_oext: Extraire dans le dossier d'origine
+txt_5_2_securedeletefree: Suppression sécurisée de l'espace libre
+txt_5_2_free: Cette opération peut prendre quelques minutes et, si elle est effectuée souvent, elle peut rapidement épuiser les disques à mémoire flash.
+txt_5_2_zerofiles: Suppression 0
+txt_5_2_zerofree: Suppression 0 de l'espace libre
+txt_5_1_schedadd: Ajouter une planification
+txt_5_1_schederr: Impossible de créer la planification
 txt_5_1_daily: Tous les jours
 txt_5_1_day: Jour
 txt_5_1_days: Jours
@@ -353,22 +353,22 @@ txt_5_1_hourly: Horaire
 txt_5_1_hours: Heures
 txt_5_1_last: Dernière
 txt_5_1_schedmanage: Planificateur de tâches, gérer les tâches enregistrées dans la branche PeaZip
-txt_5_1_scriptmanage: Gérer des scripts réguliers enregistrés
+txt_5_1_scriptmanage: Gérer les scripts planifiés enregistrés
 txt_5_1_w2: Lundi
 txt_5_1_monthly: Mensuel
 txt_5_1_months: Mois
-txt_5_1_onlogin: Activer le login
-txt_5_1_onlogin: Activer démarrer
+txt_5_1_onlogin: À la connexion
+txt_5_1_onlogin: Au démarrage
 txt_5_1_once: Fois
 txt_5_1_w7: Samedi
-txt_5_1_schedule: Annexe
-txt_5_1_schedexplain: Créer un script de texte de la définition de tâche GUI et planifier. Scripts de tâches planifiées sont enregistrés dans le dossier 'À la demande de scripts'. Pour modifier ou supprimer des tâches planifiées, que vous pouvez utiliser le planificateur de tâches du système, tous à la demande les tâches créées par PeaZip sont recueillis dans 'PeaZip' Direction générale de la bibliothèque de tâches.
-txt_5_1_schedok: Calendrier créé avec succès
-txt_5_1_schedscripts: Enregistré les scripts réguliers
+txt_5_1_schedule: Planification
+txt_5_1_schedexplain: Crée un script en texte brut à partir de la définition de tâche de l'interface graphique et le planifie. Les scripts des tâches planifiées sont enregistrés dans le dossier "Scripts planifiés". Pour modifier ou supprimer des tâches planifiées, vous pouvez utiliser le planificateur de tâches du système, toutes les tâches planifiées créées par PeaZip sont collectées dans la branche "PeaZip" de la bibliothèque de tâches.
+txt_5_1_schedok: Planification créé avec succès
+txt_5_1_schedscripts: Scripts de planification enregistrés
 txt_5_1_startdate: Date de début
 txt_5_1_starttime: Heure de début
 txt_5_1_w1: Dimanche
-txt_5_1_schedname: Nom de tâche, identifier le script régulier enregistré tant la tâche planifiée du système
+txt_5_1_schedname: Nom de la tâche, identifiez à la fois le script planifié enregistré et la tâche planifiée du système
 txt_5_1_ts: Planificateur de tâches
 txt_5_1_w5: Jeudi
 txt_5_1_w3: Mardi
@@ -376,51 +376,51 @@ txt_5_1_w4: Mercredi
 txt_5_1_weekly: Hebdomadaire
 txt_5_1_weeks: Semaines
 txt_5_0_bc: Fil d'ariane
-txt_5_0_resetpm: Confirmez-vous réinitialiser Password Manager ? Tous les mots de passe stockés dans le gestionnaire de mot de passe de PeaZip sera perdues si elle est confirmée.
+txt_5_0_resetpm: Confirmez-vous la réinitialisation du gestionnaire de mots de passe ? Tous les mots de passe stockés dans le gestionnaire de mot de passe de PeaZip sera perdus si vous confirmez.
 txt_5_0_enum: Énumérer le contenu des répertoires
 txt_5_0_music: Musique
 txt_5_0_ps: Ouvrir PowerShell ici
 txt_5_0_perf: Performances
 txt_5_0_pictures: Photos
-txt_5_0_removeall: Supprimer tous les
-txt_5_0_resetbookmarks: Réinitialiser les signets par défaut ? (Signets peuvent ensuite être personnalisés avec signets > Organiser)
+txt_5_0_removeall: Tout supprimer
+txt_5_0_resetbookmarks: Réinitialiser les Favoris par défaut ? (les Favoris peuvent ensuite être personnalisés avec Favoris > Organiser)
 txt_5_0_sh: Historique de la session
-txt_5_0_skip: Passe énumérant le contenu des répertoires dans la mise en page
+txt_5_0_skip: Ignorer l'énumération du contenu des répertoires dans la mise en page
 txt_5_0_videos: Vidéos
 txt_4_9_frame: Cadre
 txt_4_9_listth: Liste et miniatures
 txt_4_9_shadow: Ombre
 txt_4_9_style: Style
 txt_4_8_attach25: 25 Mo (limite des pièces jointes)
-txt_4_8_crop: Culture
-txt_4_8_detailsno: Navigateur de fichier léger
-txt_4_8_details: Navigateur de fichiers avec vignettes
+txt_4_8_crop: Couper
+txt_4_8_detailsno: Détails
+txt_4_8_details: Détails et vignettes
 txt_4_8_fit: S'adapter à
 txt_4_8_fitl: S'adapter au plus grand
-txt_4_8_flip: Feuilleter
+txt_4_8_flip: Retourner
 txt_4_8_fullscreen: Plein écran
 txt_4_8_fun: Fonctions
 txt_4_8_h: Hauteur
 txt_4_8_keeparchive: Conserver les archives
 txt_4_8_noresize: Conserver la taille originale
-txt_4_8_iconl: Images de grande taille
+txt_4_8_iconl: Grandes images
 txt_4_8_iconm: Icônes et images
 txt_4_8_imagemanager: Gestionnaire d'images
-txt_4_8_immersive: Immersive
-txt_4_8_listno: Liste minimale
+txt_4_8_immersive: Immersif
+txt_4_8_listno: Liste
 txt_4_8_aspect: Conserver le rapport hauteur/largeur
 txt_4_8_mirror: Miroir
 txt_4_8_presets: Préréglages
-txt_4_8_replace: Remplacer les images originales ? "Non" applique la transformation dans l'ou les nouveaux fichiers.
+txt_4_8_replace: Remplacer les images originales ? "Non" applique la transformation dans les nouveaux fichiers.
 txt_4_8_resize: Redimensionner
-txt_4_8_rl: Tourner à gauche
-txt_4_8_rr: Tourner à droite
+txt_4_8_rl: Pivoter à gauche
+txt_4_8_rr: Pivoter à droite
 txt_4_8_stop: Arrêter
 txt_4_8_t: Transformer
 txt_4_8_w: Largeur
-txt_4_7_pk: Créer mot de passe aléatoire/fichier clé
-txt_4_7_spchar: Limiter les caractères des lettres et des chiffres
-txt_4_7_recycleask: Déplacer le(s) fichier(s) sélectionné(s) dans la corbeille?
+txt_4_7_pk: Créer mot de passe/fichier clé aléatoire
+txt_4_7_spchar: Limiter les caractères aux lettres et chiffres
+txt_4_7_recycleask: Déplacer le(s) fichier(s) sélectionné(s) dans la corbeille ?
 txt_4_7_recycle: Déplacer vers la Corbeille
 txt_4_7_pcomp: Compression potentielle
 txt_4_6_am: Gestionnaire d'archives
@@ -429,38 +429,38 @@ txt_4_6_users: Utilisateurs
 txt_4_5_goupdate: Une nouvelle version est disponible. Ouvrir le site officiel de PeaZip pour télécharger la mise à jour ?
 txt_4_5_b: Bas
 txt_4_5_koupdate: Impossible de vérifier les mises à jour, aucune connexion avec le serveur de mise à jour
-txt_4_5_update: Vérification des mises à jour
-txt_4_5_dock: Quai
+txt_4_5_update: Chercher des mises à jour
+txt_4_5_dock: Dock
 txt_4_5_l: Gauche
 txt_4_5_noupdate: PeaZip est à jour
 txt_4_5_properties: Propriétés
 txt_4_5_r: Droit
-txt_4_5_pj: Enregistré les scripts de définition des emplois
+txt_4_5_pj: Scripts enregistrés
 txt_4_5_shaddress: Afficher la barre d'adresse
 txt_4_5_shnav: Afficher la barre de navigation
 txt_4_5_shstatus: Afficher la barre de statut
 txt_4_5_shtool: Afficher la barre d'outils
-txt_4_5_upxpj: Désolé, ne peut pas exporter emploi définition puisque cette action ou une option il faut effectuer plusieurs commandes distinctes
-txt_4_5_t: Top
-txt_4_4_confremoveall: Supprimer tous les fichiers de personnalisation PeaZip (Applications, signets, gestionnaire de mot de passe) ?
+txt_4_5_upxpj: Désolé, impossible d'exporter la définition de tâche car cette action ou option nécessite l'exécution de plusieurs commandes distinctes
+txt_4_5_t: Haut
+txt_4_4_confremoveall: Supprimer tous les fichiers de personnalisation PeaZip (Applications, Favoris, gestionnaire de mot de passe) ?
 txt_4_4_confremove: Supprimer la configuration de PeaZip ?
-txt_4_3_pwmanhint: Double cliquer pour modifier des éléments dans la liste de mot de passe, cliquer sur gauche pour les options, Ctrl+C pour copier des mots de passe
+txt_4_3_pwmanhint: Double cliquer pour modifier des éléments dans la liste de mot de passe, clic gauche pour les options, Ctrl+C pour copier des mots de passe
 txt_4_3_exppl: Exporter la liste de mot de passe
-txt_4_3_expple: Crypté (Gestionnaire de mot de passe de sauvegarde)
-txt_4_3_keeppw: Garder votre mot de passe/keyfile pour la session en cours
-txt_4_3_pwmanpwhint: Définir un mot de passe/keyfile (facultatif) pour crypter le mot de passe liste est recommandé, de cette façon, l'authentification seront nécessaire pour accéder au gestionnaire de mot de passe. Mot de passe/keyfile peut être modifié à tout moment de ce formulaire.
-txt_4_3_pwmanmaster: Définir/modifier le mot de passe maître
+txt_4_3_expple: Crypté (sauvegarde du Gestionnaire de mot de passe)
+txt_4_3_keeppw: Garder le mot de passe/fichier clé pour la session en cours
+txt_4_3_pwmanpwhint: Définir un mot de passe/fichier clé (facultatif) pour crypter le mot de passe liste est recommandé, de cette façon l'authentification sera nécessaire pour accéder au gestionnaire de mot de passe. Le mot de passe/fichier clé peut être modifié à tout moment depuis ce formulaire.
+txt_4_3_pwmanmaster: Définir/modifier le mot de passe principal
 txt_4_3_pwmanlist: Liste de mot de passe
 txt_4_3_pwman: Gestionnaire de mot de passe
-txt_4_3_pwmancorr: Gestionnaire de mot de passe semble trafiqués ou corrompu. Garder le gestionnaire de mot de passe de toute façon et essayer de récupérer la liste actuelle de mot de passe, si vous avez confiance elle ? (Aucun testament ne reset password manager, recommandé)
+txt_4_3_pwmancorr: Le gestionnaire de mots de passe semble falsifié ou corrompu. Garder quand même Password Manager et essayer de récupérer la liste actuelle des mots de passe, si vous lui faites confiance ? ("Non" réinitialisera le gestionnaire de mots de passe, recommandé)
 txt_4_3_expplp: Texte brut (tous les usages)
 txt_4_3_recsrc: Recherche récursive par défaut
 txt_4_3_resetpm: Réinitialiser le gestionnaire de mot de passe ? Tous les mots de passe enregistrés seront supprimés.
-txt_4_3_breadcrumb: Adresse de spectacle comme le fil d'Ariane
+txt_4_3_breadcrumb: Afficher l'adresse comme un fil d'Ariane
 txt_4_2_arcabspath: Utiliser des chemins absolus
-txt_4_1_duplicateshint: "taille"/"checksum" chaîne est signalée dans la colonne CRC pour tous les candidats en double dans le filtre actuel du répertoire ou recherche
-txt_4_1_adminhint: (HINT: alternativement, vous pouvez demander l'élévation UAC de travailler dans des chemins protégés, Alt+F10 ou Options > exécuter en tant qu'administrateur)
-txt_4_1_selected: (sélectionner)
+txt_4_1_duplicateshint: La chaîne "taille"/"somme de contrôle" est signalée dans la colonne CRC pour tous les candidats en double trouvés dans le répertoire ou le filtre de recherche actuel
+txt_4_1_adminhint: (Astuce : alternativement, vous pouvez demander l'élévation UAC pour travailler dans des chemins protégés, Alt+F10 ou Options > Exécuter en tant qu'administrateur)
+txt_4_1_selected: (sélectionné)
 txt_4_1_duplicatesfound: doublons trouvés
 txt_4_1_duplicatesfind: Rechercher les doublons
 txt_4_1_runasadmin: Exécuter en tant qu'administrateur
@@ -468,58 +468,58 @@ txt_4_1_simplesearch: Recherche simple
 txt_4_0_thim: Afficher les vignettes d'image
 txt_3_8_type_description_wim: WIM: Format d'image disque de Microsoft
 txt_3_8_type_description_xz: XZ: compression d'un fichier puissant basée sur LZMA2
-txt_3_7_donations: Un grand merci nous faire un dons.
-txt_3_7_nameasparent: Archive nom comme dossier parent de l'élément sélectionné, si plusieurs éléments sont ajoutés.
-txt_3_7_tracker: PeaZip tracker: bugs, demandes de fonctionnalité
+txt_3_7_donations: Faire un don
+txt_3_7_nameasparent: Nommer l'archive comme le dossier parent de l'élément sélectionné, si plusieurs éléments sont ajoutés
+txt_3_7_tracker: PeaZip tracker: bugs, demandes de fonctionnalités
 txt_3_7_sort: Trier par
-txt_3_7_swapbars: La barre d'outils d'échange/barre d'adresses
-txt_3_7_themedbars: Barres de thème
-txt_3_6_ignoredd: Toujours ignorer les chemins pour glisser et déplacer d'extraction
+txt_3_7_swapbars: Permuter barre d'outils / barre d'adresse
+txt_3_7_themedbars: Barres thématiques
+txt_3_6_ignoredd: Toujours ignorer les chemins pour les extractions par glisser-déposer
 txt_3_6_close: Fermer
-txt_3_6_resetapps: Vous voulez réinitialiser les applications (groupe personnalisable des programmes et des scripts pour ouvrir des fichiers avec substitution des associations de fichiers) ?
+txt_3_6_resetapps: Vous voulez réinitialiser les applications (groupe personnalisable des programmes et des scripts pour ouvrir des fichiers, remplace les associations de fichiers par défaut) ?
 txt_3_6_ethemes: Thèmes existants
 txt_3_5_td: Télécharger les thèmes
 txt_3_5_managecustomthemes: Gérer les thèmes
 txt_3_4_nopaths: Pas de répertoire
-txt_3_4_smallicons: Petites icônes
+txt_3_4_smallicons: Icônes
 txt_3_3_skipunits: (Windows) Obtenir des informations de volume pour les unités de réseau (ralenti le démarrage)
 txt_3_3_stralt: Commande alternative, lorsqu'aucun paramètre n'est transmis
 txt_3_3_apps: Applications
 txt_3_3_multi: Sélection multiple
-txt_3_3_runexp: Ouvrir un programme, le fichier, le dossier ou le site Web
-txt_3_3_apppath: Ouvrir le dossier du PeaZip
+txt_3_3_runexp: Ouvrir un programme, fichier, dossier ou site Web
+txt_3_3_apppath: Ouvrir le dossier de PeaZip
 txt_3_3_run: Exécuter
-txt_3_2_7zutf8nonascii: 7Z/p7zip - mcu utiliser UTF-8 pour les noms de fichier contenant les symboles non-ASCII à l'intérieur de fichiers .zip
+txt_3_2_7zutf8nonascii: 7Z/p7zip -mcu utilise UTF-8 pour les noms de fichier contenant des symboles non-ASCII à l'intérieur de fichiers .zip
 txt_3_2_alltasks: Toutes les tâches
 txt_3_2_conf: Configuration
-txt_3_2_donations: Faire un don de bienfaisance
-txt_3_1_sccenc: Codage de caractères 7z/p7zip - scc
+txt_3_2_donations: Faire un don à des organisations caritatives
+txt_3_1_sccenc: Codage de caractères 7z/p7zip dans la CONSOLE (-scc)
 txt_3_1_downloads: Téléchargements
 txt_3_1_lib: Bibliothèques
-txt_3_1_more: Renseignements
-txt_3_1_openasarchive: Ouvrir l'archive
-txt_3_1_sendto: Ouvrir le dossier de l'utilisateur envoyer à menu
-txt_3_1_pathexc: Chemin dépassant la taille maximale autorisée
+txt_3_1_more: Plus
+txt_3_1_openasarchive: Ouvrir en tant qu'archive
+txt_3_1_sendto: Dossier du menu Envoyer vers de l'utilisateur
+txt_3_1_pathexc: Le chemin dépasse la taille maximale autorisée
 txt_3_1_recent: Récents
-txt_3_1_plsmartmin: Exécuter réduit, salon/keep ouvrir uniquement si nécessaire
+txt_3_1_plsmartmin: Exécuter minimisé, afficher/garder ouvert uniquement si nécessaire
 txt_3_1_src: Recherches
-txt_3_1_systmp: Système temp
-txt_3_1_languagetools: Traduire !
+txt_3_1_systmp: Dossier temporaire de l'utilisateur
+txt_3_1_languagetools: Traduire
 txt_3_1_workingdir: Répertoire de travail
-txt_3_0_nonreadableorpw: Archive semble non lisible ou protégés par mot de passe
-txt_3_0_readablepw: Archive semble le mot de passe protégé
-txt_3_0_configure: Configurer les associations de fichiers, menu contextuel et menu Envoyer vers
-txt_3_0_resettmp: Réinitialiser le dossier temporaire de Peazip (peazip-tmp).
+txt_3_0_nonreadableorpw: L'archive n'est pas lisible. L'archive peut ne pas être valide, des volumes peuvent être manquants ou sa table des matières peut être cryptée. Voulez-vous essayer un mot de passe ?
+txt_3_0_readablepw: Archive semble protégée par mot de passe
+txt_3_0_configure: Associations de fichiers et intégration au menu système
+txt_3_0_resettmp: Réinitialiser le dossier temporaire de Peazip (peazip-tmp)
 txt_2_9_address: Barre d'adresse
-txt_2_9_adv: Les filtres avancés sont appliqués pour tous les fichiers supportés par 7z ou FreeArc, voir la documentation, et ignorent les filtres basiques (utilisés pour des fonctions de recherche et qui sont affichés dans des panneaux de signets et de l'historique)
+txt_2_9_adv: Les filtres avancés sont appliqués pour tous les fichiers supportés par 7z ou FreeArc, voir la documentation, et ignorent les filtres basiques (utilisés pour des fonctions de recherche et qui sont affichés dans des panneaux de favoris et de l'historique)
 txt_2_9_columns: Colonnes
 txt_2_9_copyhere: Copier ici
 txt_2_9_noscan: Ne pas analyser les fichiers ajoutés à disposition
-txt_2_9_extconsole: Console d'extraction est disponible uniquement lors de la consultation des archives
-txt_2_9_thl: Mettre en surbrillance des boutons
+txt_2_9_extconsole: La console d'extraction est disponible uniquement lors de la consultation des archives
+txt_2_9_thl: Mettre en surbrillance les boutons
 txt_2_9_home: Accueil
 txt_2_9_lt: Grand
-txt_2_9_mt: Medium
+txt_2_9_mt: Moyen
 txt_2_9_movehere: Déplacer ici
 txt_2_9_nav: Navigation
 txt_2_9_navbar: Barre de navigation
@@ -528,18 +528,18 @@ txt_2_9_organize: Organiser
 txt_2_9_public: Public
 txt_2_9_rec: Recursive: Rechercher dans les sous-répertoires, peut prendre un certain temps
 txt_2_9_selected: Sélectionné
-txt_2_9_setapps: Définies des applications privilégiées
+txt_2_9_setapps: Organizer les applications
 txt_2_9_showmenu: Afficher la barre de menu
 txt_2_9_st: Petit
-txt_2_9_test_pw2G:Test pour le chiffrement <des qu'archives de 2 Go
+txt_2_9_test_pw2G: Test pour le chiffrement des archives < 2 GB
 txt_2_9_vst: Texte uniquement
 txt_2_9_toolbar: Barre d'outils
 txt_2_9_tree: Arborescence
 txt_2_9_views: Affichage
 txt_2_8_experimental: (experimental)
-txt_2_8_zcopy: (Windows) Copier les fichiers en mode redémarrable (plus lent)
+txt_2_8_zcopy: (Windows) Copier les fichiers en mode redémarrable (copie plus lente)
 txt_2_8_addvol: Ajouter des volumes entiers à l'archive peu prendre du temps. Voulez-vous continuer ?
-txt_2_8_uniterror: Impossible d'accéder à unité
+txt_2_8_uniterror: Impossible d'accéder à l'unité
 txt_2_8_cannotconvert: Impossible de convertir les archives sélectionnées
 txt_2_8_convertbegin: Poursuivre avec l'étape de compression pour finaliser la conversion ?
 txt_2_8_convert: Convertir
@@ -547,110 +547,110 @@ txt_2_8_convertexisting: Convertir les archives existantes
 txt_2_8_convertdelete: Supprimer les fichiers et répertoires créés temporairement pour la conversion ?
 txt_2_8_details: Détails
 txt_2_8_parallel: Exécuter si possible les tâches en parallèle
-txt_2_8_convertnote: Dans le cas où l'archive initiale a été modifiée, donne à l'utilisateur la possibilité de la garder ou de la supprimer
-txt_2_8_custom: n'est pas directement supporté par PeaZip, mais à l'étape d'extraction, vous pouvez personnaliser PeaZip pour les types de fichiers gérés dans l'onglet "Avancé". Poursuivre et ouvrir ce fichier ?
-txt_2_8_unitrecommend: Il est recommandé soit d'extraire (clique-droit > sélectionner Extraire) ou d'ouvrir le système de fichiers depuis la racine (Outils système > Ouvrir l'unité comme une archive)
-txt_2_8_viewasarchive: Ouvrir l'unité comme une archive
+txt_2_8_convertnote: Dans tous les cas, les archives d'origine n'ont pas été modifiées, pour laisser à l'utilisateur le contrôle de leur conservation ou de leur suppression
+txt_2_8_custom: n'est pas directement pris en charge par PeaZip, mais au stade de l'extraction, vous pouvez configurer PeaZip pour qu'il gère les types de fichiers personnalisés dans l'onglet "Avancé". Continuer à ouvrir ce fichier ?
+txt_2_8_unitrecommend: Il est recommandé soit d'extraire (clic droit > extraire sélectionné) soit d'ouvrir les systèmes de fichiers depuis la racine de l'ordinateur (Outils système > Ouvrir l'unité en tant qu'archive)
+txt_2_8_viewasarchive: Ouvrir l'unité en tant qu'archive
 txt_2_8_nounit: Aucune unité sélectionnée
-txt_2_8_rowselect: Sélection par rangée
+txt_2_8_rowselect: Sélection de ligne
 txt_2_8_statusbar: Barre d'état
 txt_2_8_typeunit: Entrer un nom d'unité logique ou physique
-txt_2_8_usedefaultoutpath: Utiliser la sortie par défaut
+txt_2_8_usedefaultoutpath: Toujours utiliser la sortie par défaut
 txt_2_7_experimental: (experimental, voir la documentation)
 txt_2_7_optional: (optionnel)
-txt_2_7_list_tryflatorpw: , solutions possibles: essayer d'afficher à plat (F6), donner un pot de passe (F9), ré-essayer une copie récente de l'archive
-txt_2_7_separate: Ajouter chaque objet dans une archive séparée
+txt_2_7_list_tryflatorpw: , solutions possibles : essayez l'affichage à plat (F6), fournissez un mot de passe (F9), obtenez une nouvelle copie de l'archive
+txt_2_7_separate: Ajouter à des archives séparées
 txt_2_7_pwsupported: archivage avec mot de passe
 txt_2_7_cancel: Annuler
-txt_2_7_encfn: Chiffrer également les noms de fichier.txt (si pris en charge par le format)
-txt_2_7_setpw: Entrer le mot de passe/un fichier clef
+txt_2_7_encfn: Chiffrer également les noms de fichier (si pris en charge par le format)
+txt_2_7_setpw: Entrer le mot de passe/fichier clef
 txt_2_7_ext: Extraction:
 txt_2_7_extfrom: Extraction de l'archive:
-txt_2_7_es: Extrait de prise en charge non-archive fichier.txt types, Internet Explorer les fichiers exécutables, les fichiers MS Office et OOo
-txt_2_7_eu: Extraire les types fichier.txt non pris en charge, spécifiant l'utilitaire d'extraction personnalisée
-txt_2_7_clipboard: Dossier de presse-papiers du navigateur
-txt_2_7_goarclayout: Aller à "l'archivage de mise en page
+txt_2_7_es: Extraire les types de fichiers non archivés pris en charge (par exemple les exécutables, les fichiers MS Office et OOo, ...)
+txt_2_7_eu: Extraire les types de fichier non pris en charge, spécifiant l'utilitaire d'extraction personnalisé
+txt_2_7_clipboard: Presse-papiers
+txt_2_7_goarclayout: Aller à la disposition de l'archivage
 txt_2_7_goextlayout: Aller à la disposition de l'extraction
 txt_2_7_ok: OK
-txt_2_7_drag_archive: Ouvrir le fichier comme nouvelle archive ? ("Non" à ajouter. fichier.txt actuelle "archivage disposition)
-txt_2_7_oop: Chemin de sortie ouverte lors de la tâche est terminée
-txt_2_7_validatefn: Nom de fichier non valide d'opération, s'est arrêté détectés:
-txt_2_7_validatecl: Opération, commande potentiellement dangereux arrêté détectés (Internet Explorer non autorisé concaténation commande au sein du programme):
+txt_2_7_drag_archive: ouvrir le fichier en tant que nouvelle archive ? ("Non" pour ajouter le fichier à la disposition d'archivage actuelle)
+txt_2_7_oop: Ouvrir le chemin de sortie lorsque la tâche est terminée
+txt_2_7_validatefn: Opération arrêtée, nom de fichier non valide détecté :
+txt_2_7_validatecl: Opération arrêtée, commande potentiellement dangereuse détectée (par exemple la concaténation de commandes n'est pas autorisée dans le programme) :
 txt_2_7_output: Sortie
-txt_2_7_pwnotset: Mot de passe n'est pas définie
-txt_2_7_pwarcset: Mot de passe est défini
-txt_2_7_pwextset: Mot de passe est défini, il est possible d'archives cryptés extrait/liste/test
-txt_2_7_archivehint: À droite cliquer pour ajouter. fichiers d'archiver et à voir d'autres fonctions ou faites glisser les fichiers disponibles ICIS à ajouter
-txt_2_7_exthint: À droite, cliquer sur Ajouter. fichiers à extraire à et à voir d'autres fonctions ou faites glisser les fichiers disponibles ICIS pour être extraites
+txt_2_7_pwnotset: Le mot de passe n'est pas défini
+txt_2_7_pwarcset: Le mot de passe est défini
+txt_2_7_pwextset: Le mot de passe est défini, il est possible d'extraire/lister/tester les archives cryptées
+txt_2_7_archivehint: Faites glisser ici les fichiers et dossiers à archiver, ou faites un clic droit pour plus d'options
+txt_2_7_exthint: Faites glisser ici les archives à extraire, ou faites un clic droit pour plus d'options
 txt_2_7_setadvf: Définir les filtres avancés
 txt_2_7_selpath: Chemin de l'élément sélectionné
-txt_2_7_separateerror: Désolé, ne peut pas importer ligne de commande de définition de tâche tout en utilisant "ajouter chaque objet à une archive séparée" commutateur, étant donné que la tâche est exécutée comme instruction plusieurs commandes distinctes
-txt_2_7_noinput: La mise en page est vide: Veuillez utiliser pour ajouter un/des fichier (s) ou clauses à préparer de la liste de mise en charge des archives à être extraites
-txt_2_7_dirsize: La taille du contenu des dossiers n'est pas cochée pour calculer la taille totale
-txt_2_7_un7z_browse_flat: Essayer d'afficher plate (F6)
-txt_2_7_updating: Mise à jour, ajoutant à une archive existante:
+txt_2_7_separateerror: Désolé, impossible d'importer la ligne de commande de la définition de tâche lors de l'utilisation du commutateur "Ajouter à des archives distinctes", car la tâche est exécutée sous la forme de plusieurs commandes distinctes
+txt_2_7_noinput: La disposition est vide : veuillez utiliser Ajouter fichier(s) ou Charger la disposition pour remplir la liste des archives à extraire
+txt_2_7_dirsize: La taille du contenu des dossiers n'est pas vérifiée pour calculer la taille totale
+txt_2_7_un7z_browse_flat: Essayer d'afficher à plat (F6)
+txt_2_7_updating: [Mise à jour de l'archive existante]
 txt_2_6_folders: (dossiers)
 txt_2_6_advanced: Avancé
-txt_2_6_plalways: Garder toujours ouvert à inspecter le rapport du projet
-txt_2_6_plsmart: Maintenir ouverte uniquement si nécessaire (rapports d'erreur, de liste ou de test)
+txt_2_6_plalways: Toujours arrêter pour inspecter le rapport de tâche
+txt_2_6_plsmart: Arrêter pour inspecter le rapport d'erreur, liste, test
 txt_2_5_sessionio: (cette session)
-txt_2_5_advanced: Avancées d'édition: placer des espaces entre les chaînes de paramètre et nom de fichier si nécessaire
-txt_2_5_basic: Édition de base: application et les paramètres avant le nom d'entrée
-txt_2_5_cannotrun: Ne peut pas s'exécuter
-txt_2_5_custeditors: Éditeurs personnalisés, les joueurs, antivirus scanneurs etc.... remplacer les associations de fichiers du système
+txt_2_5_advanced: Édition avancée : placer des espaces entre les chaînes de paramètre et noms de fichier si nécessaire
+txt_2_5_basic: Édition de base : l'application et les paramètres sont avant le nom d'entrée
+txt_2_5_cannotrun: Ne peut pas exécuter
+txt_2_5_custeditors: Éditeurs personnalisés, lecteurs, antivirus, etc... (remplace les associations de fichiers du système)
 txt_2_5_delete: Supprimer
-txt_2_5_delete_fromarchive: Supprimer les archives
-txt_2_5_langflag: Afficher nom de l'objet archivés comme du texte UTF-8; désactiver pour remplacer des caractères étendus avec "?"
+txt_2_5_delete_fromarchive: Supprimer de l'archive
+txt_2_5_langflag: Afficher nom de l'objet archivés comme du texte UTF-8; décocher pour remplacer des caractères étendus avec "?"
 txt_2_5_encpj: Coder la définition de tâche sous forme de texte UTF-8
 txt_2_5_execommand: Fichier exécutable ou commande
 txt_2_5_help: Aide
-txt_2_5_langhint: Indication: remplacement des caractères étendus avec "?" jolly caractère peut améliorer syntaxe si jeu de caractères l'archive ne peut pas être converti avec succès sur l'ordinateur actuel
+txt_2_5_langhint: Astuce : remplacer les caractères étendus par "?" peut améliorer la syntaxe si le jeu de caractères de l'archive ne peut pas être converti avec succès sur la machine actuelle
 txt_2_5_mini_help: Mini tutoriel
 txt_2_5_offline_help: Aide de PeaZip
-txt_2_5_tray: Réduire dans la barre de tâche
-txt_2_5_remove: Supprimer
-txt_2_5_hintpaths: clique droit pour ouvrir les chemins d'accès du système et de l'utilisateur
-txt_2_5_selectapp: Sélectionner application
-txt_2_5_strafter: Après le nom d'entrée de chaîne
+txt_2_5_tray: Réduire dans la barre des tâches
+txt_2_5_remove: Enlever
+txt_2_5_hintpaths: clic droit pour ouvrir les chemins d'accès du système et de l'utilisateur
+txt_2_5_selectapp: Sélectionner une application
+txt_2_5_strafter: Chaîne de caractères après le nom d'entrée
 txt_2_5_strbefore: Chaîne de caractères avant le nom d'entrée
 txt_2_5_encoding: Codage de texte
 txt_2_5_nopw: ce type d'archives ne prend pas en charge le chiffrement
-txt_2_4_draghint: [déposer dans l'explorateur avec la barre d'adresse]
-txt_2_4_tb: Adapter les boutons de la barre d'outils (redémarrer PeaZip)
+txt_2_4_draghint: [faire glisser vers l'explorateur avec la barre d'adresse activée]
+txt_2_4_tb: Adapter les boutons de la barre d'outils (redémarrage nécessaire)
 txt_2_4_adding: Ajouter
-txt_2_4_advclip: Avancé: garder les sélections multiple dans le porte-documents (pas de doublon), effacer au collage
+txt_2_4_advclip: Le presse-papiers conserve plusieurs sélections
 txt_2_4_yanswers: Réponses
-txt_2_4_itemsheight: Redimensionner automatiquement les hauteurs d'items
-txt_2_4_clearclipboard: Effacer le porte-documents (Esc)
-txt_2_4_wcommons: Communs
+txt_2_4_itemsheight: Redimensionner automatiquement la hauteur des éléments
+txt_2_4_clearclipboard: Effacer le presse-papiers (Échap)
+txt_2_4_wcommons: Courants
 txt_2_4_copyfrom: Copier à partir de
-txt_2_4_deletebookmarks: Voulez-vous supprimer la liste de fichiers marqués et les dossiers ?
+txt_2_4_deletebookmarks: Voulez-vous supprimer la liste des fichiers et dossiers favoris ?
 txt_2_4_documents: Mes documents
 txt_2_4_wenc: Encyclopédie
 txt_2_4_extractfrom: Extraire à partir de
-txt_2_4_hexp: Prévisualisation Hex
+txt_2_4_hexp: Prévisualisation hexadécimale
 txt_2_4_operation: Opération
-txt_2_4_path: Le répertoire est en lecture seule, choisisser un autre dossier
-txt_2_4_removefromclipboard: Supprimer à partir du porte-documents
-txt_2_4_stdclip: Standard: Ne garder qu'une seule sélection dans le porte-documents, effacer les opérations de coupe au collage
-txt_2_4_totalmem: Mémoire totale
+txt_2_4_path: path n'est pas accessible en écriture (lecture seule). Voulez-vous sélectionner un chemin de sortie inscriptible ?
+txt_2_4_removefromclipboard: Supprimer à partir du presse-papiers
+txt_2_4_stdclip: Standard: Ne garder qu'une seule sélection dans le presse-papiers, effacer les opérations de coupe au collage
+txt_2_4_totalmem: mémoire totale
 txt_2_4_gvideo: Vidéo
-txt_2_4_wbook: Livre de wiki
-txt_2_4_wnews: Nouvelles de wiki
-txt_2_4_wsrc: Source de wiki
+txt_2_4_wbook: Wikibook
+txt_2_4_wnews: Wikinews
+txt_2_4_wsrc: Wikisource
 txt_2_4_wdict: Wiktionnaire
-txt_2_3_pw_errorchar:: Ce caractère ne peut pas être utilisé par PeaZip dans les mots de passe avec ce système, modifier le mot de passe ou choisisser le mode Console dans Outils > Paramètres
-txt_2_3_envstr: Variables d'affichage
-txt_2_3_never_pw: Ne plus demander de mot de passe
-txt_2_3_home: Utilisateur
-txt_2_3_on_pw: Sur les opérations d'extraction/liste/essai des menus système:
-txt_2_3_test_pw100: Test pour le cryptage des archives <100Mo
-txt_2_3_test_pw: Test pour le cryptage (lent)
-txt_exclude_recourse: "Exclusion" des sous-répertoires
+txt_2_3_pw_errorchar: il n'est pas recommandé d'utiliser le guillemet dans les mots de passe (pour PeaZip et les scripts). Si vous avez besoin de créer ou d'extraire une archive avec ce mot de passe, vous pouvez ignorer le message et il vous sera demandé de saisir le mot de passe de manière interactive dans la console.
+txt_2_3_envstr: Afficher les variables d'environnement
+txt_2_3_never_pw: Ne pas demander de mot de passe
+txt_2_3_home: Dossier d'accueil de l'utilisateur
+txt_2_3_on_pw: Sur les opérations d'extraction/liste/test à partir des menus du système :
+txt_2_3_test_pw100: Test pour le cryptage des archives < 100 MB
+txt_2_3_test_pw: Test pour le cryptage (peut être lent)
+txt_exclude_recourse: "exclure" les sous-répertoires récursifs
 txt_action_extopen: "Extraire et ouvrir avec l'application associée"
-txt_error_passwordnotmatch: Le "mot de passe" et la "Confirmation" ne correspondent pas: veuillez corriger !
-txt_action_preview: "Afficher avec l'application associée"
-txt_preview_hint: "L'action de prévisualisation exécute la même tâche qu'Extraire et Ouvrir  mais dans un dossier provisoire dans le répertoire de destination, il sera automatiquement supprimé à la fermeture de l'archive.
+txt_error_passwordnotmatch: Les champs "Mot de passe" et "Confirmation" ne correspondent pas, veuillez les corriger
+txt_action_preview: "Prévisualiser avec l'application associée"
+txt_preview_hint: L'action de prévisualisation exécute la même tâche qu'Extraire et Ouvrir mais dans un dossier provisoire dans le répertoire de destination, il sera automatiquement supprimé à la fermeture de l'archive.
 txt_better: (meilleur)
 txt_default2: (par défaut)
 txt_faster: (rapide)
@@ -658,168 +658,168 @@ txt_fastermem: (plus rapide, moins de mémoire)
 txt_tempdir: (dossier temporaire de PeaZip)
 txt_stream: (réglé avec le "contrôle du flux")
 txt_slowermem: (plus lent, plus de mémoire)
-txt_store: (stocker, plus rapide)
+txt_store: (stockage, plus rapide)
 txt_newfolder: (dans nouveau dossier)
-txt_7z_exitcodeunknown:: Erreur inconnue 
-txt_list_isfolder: [dossier]
+txt_7z_exitcodeunknown: : Erreur inconnue dans la tâche
+txt_list_isfolder:  [dossier]
 txt_none: <aucun>
 txt_fd: Lecteur de disquette 1.44 Mo
-txt_7z_exitcode1: 1: Attention: Erreur non-fatale. Ex: quelques fichiers sont manquants ou bloqués
-txt_attach10: 10 Mo (limite d'attachement)
+txt_7z_exitcode1: 1: Attention: Erreur(s) non-fatale; par exemple quelques fichiers sont manquants ou bloqués
+txt_attach10: 10 Mo (pièce-jointe)
 txt_7z_exitcode2: 2: Erreur fatale
-txt_7z_exitcode255: 255: interrompu par l'utilisateurr
+txt_7z_exitcode255: 255: Tâche interrompue par l'utilisateurr
 txt_fat32: 4 Go (taille max. des fichiers FAT32)
-txt_dvd: 4.7 Go DVD
-txt_attach5: 5 Mo (limite d'attachement)
-txt_cd650: 650 Mo CD
+txt_dvd: 4.7 Go (DVD)
+txt_attach5: 5 Mo (pièce-jointe)
+txt_cd650: 650 Mo (CD)
 txt_7z_exitcode7: 7: Erreur: ligne de commande incorrecte
-txt_cd700: 700 Mo CD
-txt_type_description_7z: 7Z: format d'archive riches en fonctionnalités avec un taux de compression élevé
-txt_dvddl: 8.5 Go DVD DL
+txt_cd700: 700 Mo (CD)
+txt_type_description_7z: 7Z: format d'archive riche en fonctionnalités avec taux de compression élevé
+txt_dvddl: 8.5 Go (DVD DL)
 txt_7z_exitcode8: 8: Erreur: mémoire insuffisante pour l'opération demandée
 txt_abort: Abandonner les opérations planifiées de copie/déplacement de fichier ?
-txt_about: À propos de
+txt_about: À propos
 txt_action: Action
 txt_action_hint: Action lors de l'ouverture ou la prévisualisation avec l'application associée
 txt_add: Ajouter
 txt_add_existing_archive: Ajouter (si l'archive existe)
 txt_add_archive: Ajouter une archive
-txt_add_files: Ajouter des fichier(s)
+txt_add_files: Ajouter des fichiers
 txt_add_folder: Ajouter un dossier
-txt_add_path: Ajouter un répertoire
+txt_add_path: Ajouter un chemin
 txt_add_tolayout: Ajouter les fichiers et les dossiers sélectionnés à l'archive
-txt_add_toarchive: Ajouter une archive
-txt_add_tobookmarks: Ajouter un favoris
-txt_address_hint: Adresse: Accepte les caractères de remplacement ? pour les caractères et * pour les séries; les " ou ' ne sont pas nécessaires
+txt_add_toarchive: Ajouter à une archive
+txt_add_tobookmarks: Ajouter aux favoris
+txt_address_hint: Filtre : accepte les caractères de remplacement * et ?
 txt_adv_filters: Filtres avancés
 txt_algo: Algorithme
-txt_all: tous
+txt_all: tout
 txt_all_default: Tout (par défaut)
-txt_all_type: Tous les objets de ce type
-txt_all_date: Tous les objets avec cette date...
-txt_all_psize: Tous les objets avec la même taille de package...
-txt_all_attributes: Tous les objets avec ces mêmes attributs
-txt_all_size: Tous les objets de cette taille...
-txt_error_input_upx: permet un fichier exécutable unique en Entrée
+txt_all_type: Même type
+txt_all_date: Date
+txt_all_psize: Taille du fichier compressé
+txt_all_attributes: Mêmes attributs
+txt_all_size: Taille de fichier
+txt_error_input_upx: accepte un fichier exécutable unique en entrée
 txt_always_pw: Toujours demander le mot de passe
 txt_ignore_ext: Toujours ignorer les répertoires pour "Extraire et..."
 txt_ignore_disp: Toujours ignorer les répertoires pour "Extraction affichée..."
 txt_ignore_sel: Toujours ignorer les répertoires pour "Extraire la sélection..."
-txt_key_hint: Ajouter la clé de hash du mot de passe, l'archive peut être déchiffré par PeaZip et d'autres applications en suivant la même norme ou entrer le hash dans le mot de passe
-txt_timestamp: Ajouter l'heure/date au nom de l'archive
+txt_key_hint: Ajouter la clé de hash du mot de passe, l'archive peut être déchiffré par PeaZip et d'autres applications en suivant la même norme ou en entrant le hash dans le mot de passe
+txt_timestamp: Ajouter l'horodatage au nom
 txt_appoptions: Options des application
 txt_type_description_arc: ARC: archiveur expérimental, puissant, efficace et riche en fonctionnalités
 txt_archive: Archive
 txt_un7z_browse_ok: archives explorée avec succès
-txt_interface: Interface du navigateur des Archives 
+txt_interface: Interface du navigateur d'archives 
 txt_archivecreation: Création d'une archive
-txt_tarbefore_hint: Archivage des données au format TAR avant d'en indiquer le type.
+txt_tarbefore_hint: Archiver les données au format TAR avant le type spécifié.
 txt_archive_hint: Archive, compresser, scinder et garder les fichiers, les dossiers privés et les volumes
-txt_compressionratio_hint: Taux de compression de l'Archive
+txt_compressionratio_hint: Taux de compression de l'archive
 txt_archiving: Archivage:
-txt_cl_long: Les arguments semblent dépasser la taille maximale que peut être transmis à PeaZip, sélectionner moins de fichiers (ex: sélectionner le répertoire au lieu des fichiers)
-txt_overwrite_askbefore: Demander avant d'écraser (à utiliser dans le mode console)
-txt_associated: application associée
+txt_cl_long: Les arguments semblent dépasser la taille maximale qui peut être transmise à PeaZip, veuillez sélectionner moins de fichiers (ex: sélectionner le répertoire au lieu des fichiers)
+txt_overwrite_askbefore: Demander avant d'écraser (dans la console)
+txt_associated: Application associée
 txt_attributes: Attributs
 txt_author: Auteur
 txt_ren_existing: Renommer automatiquement les fichiers existants
 txt_ren_extracted: Renommer automatiquement les fichiers extraits
-txt_autofolder: Créer automatiquement un nouveau dossier pour extraire l'archive ?
+txt_autofolder: Créer automatiquement un nouveau dossier pour y extraire l'archive ?
 txt_back: Précédent
-txt_backend: Interface utilisateur binaire Backend
+txt_backend: Binaires principaux
 txt_backupexe: Sauvegarder l'exécutable (recommandé)
 txt_bettercompression: meilleure compression
 txt_blogs: Blogs
 txt_blowfish: Blowfish448 (blocs 64 bits)
 txt_bookmarks: Favoris
 txt_browse: Rechercher
-txt_browser: Explorer
-txt_aborted_error: L'exploration de l'archive s'est arrêté, cela prendrait trop de temps. Vous pouvez réduire la sélection en utilisant la fonction de filtrage de recherche ou des filtres (ou en quittant "Afficher à plat"); Les opérations d'extractions/liste/essai ne seront pas affectées)
-txt_list_browsing: Exploration:
+txt_browser: Explorateur de fichiers
+txt_aborted_error: La navigation dans l'archive s'est arrêtée, cela prendrait trop de temps. Vous pouvez affiner la sélection en utilisant la recherche (F3) ou en évitant le mode d'affichage à plat (F6). Vous pouvez directement extraire, lister ou tester l'archive.
+txt_list_browsing: Exploration
 txt_archive_root: Exploration: racine de l'archive
 txt_type_description_bzip2: BZip2: compression puissante, vitesse moyenne
-txt_pw_empty: N'accepte pas le mot de passe vide, saisisser un mot de passe ou désactiver l'option "Crypter"
-txt_add_error: Impossible d'ajouter, mettre à jour ou de supprimer un objet, le type d'archive ne supporte que l'exploration/l'extraction ou ne supporte pas cette opération ou PeaZip ne peut pas manipuler entièrement ce nom d'archive
+txt_pw_empty: Veuillez fournir un mot de passe (ou un fichier clé)
+txt_add_error: Impossible d'ajouter/de mettre à jour ou de supprimer des objets. L'archive n'est pas accessible en écriture ou ne peut pas prendre en charge cette opération. La modification des types d'archives non canoniques peut être activée dans les options du gestionnaire d'archives.
 txt_un7z_browse_failure: exploration d'archive impossible
-txt_list_error: Impossible de lister le contenu de l'archive, vérifier si l'archive n'est pas protégée par un mot de passe ou qu'elle ne soit pas corrompue.
+txt_list_error: Impossible de lister le contenu de l'archive, vérifiez si l'archive n'est pas protégée par un mot de passe ou qu'elle ne soit pas corrompue.
 txt_conf_cannotsave: Impossible d'enregistrer le fichier de configuration, vérifier si le répertoire d'accès est en lecture seule et s'il y a un peu d'espace libre
-txt_check_hint: Vérifier les corruptions de données occasionnelles; les algorithmes de hash peuvent détecter la falsification de données malveillants (voir la documentation)
-txt_check: Fichier la somme de contrôle/hachage
-txt_check_select: la somme de contrôle/hachage à effectuer
+txt_check_hint: Vérifiez la corruption occasionnelle des données ; les algorithmes de hachage conviennent pour détecter même la falsification malveillante des données (voir la documentation)
+txt_check: Fichier(s) de somme de contrôle/hachage
+txt_check_select: Somme de contrôle/hachage
 txt_clear: Effacer
-txt_clearlayout: Effacer la mise en page
-txt_pj_hint: Cliquer sur Importation, Réinitialiser les changements et mise à jour de l'interface graphique
+txt_clearlayout: Effacer la disposition
+txt_pj_hint: Cliquez pour importer la tâche, réinitialiser les modifications et charger la définition de tâche à jour à partir de l'interface graphique
 txt_autoclose: Fermer PeaLauncher lorsque le travail est terminé
 txt_cl: ligne de commande:
 txt_compare: Comparer des fichiers
-txt_compress: Compression
+txt_compress: Compresser
 txt_compress_executable: Compresser un exécutable
 txt_compress_openforwriting: Compresser des fichiers ouverts pour l'écriture
 txt_compression: Compression
 txt_compmanagement: Gestion de l'ordinateur
-txt_pw_confirm: Confirmer le mot de passe
+txt_pw_confirm: Confirmer
 txt_console: Console
-txt_console_interface: console: interface native
+txt_console_interface: Console: interface native
 txt_content: Contenu
 txt_controlpanel: Panneau de configuration
 txt_convert: Convertir un disque en NTFS
-txt_copy: Copier (Ctrl+C)
+txt_copy: Copier
 txt_copyto: Copier dans...
 txt_create: Créer
-txt_create_archive: Créer une archive
+txt_create_archive: Créer une nouvelle archive
 txt_title_create: Créer, compresser, encrypter, scinder une archive...
 txt_create_keyfile: Créer un fichier clef
 txt_create_folder: Créer un nouveau dossier
-txt_create_theme: Créer un nouveau thème à partir des paramètres actuels:
+txt_create_theme: Créer un nouveau thème à partir des paramètres actuels
 txt_rr: Créer des rapports de récupérations
-txt_create_sfx: Créer des fichiers auto-extractibles
+txt_create_sfx: Créer des archives auto-extractibles
 txt_cr_current: Répertoire ou filtre de taux de compression actuel
 txt_custom: Personnaliser
 txt_type_description_custom: Personnaliser (utilisateurs expérimentés): entrer le nom et les paramètres de l'exécutable
-txt_customapp: Personnaliser l'application
+txt_customapp: Application personnalisée
 txt_custom_parameters: Personnaliser les paramètres
 txt_customsize: Personnaliser la taille
-txt_cut: Couper (Ctrl+X)
+txt_cut: Couper
 txt_datetime: Date/heure
-txt_default: Par défaut
-txt_default_compression: Compression par défaut
+txt_default: par défaut
+txt_default_compression: compression par défaut
 txt_default_format: Format par défaut
 txt_theme_default: Thème par défaut
-txt_hard_reset_hint: Supprimer le fichier des signets
+txt_hard_reset_hint: Supprimer le fichier des favoris
 txt_desktop: Bureau
 txt_dictionary: Dictionnaire
-txt_dirs: Répertoire(s),
-txt_dis: Désambiguïsation:
+txt_dirs: répertoire(s),
+txt_dis: Clarification:
 txt_disk_cleanup: Nettoyer le disque
 txt_disk_defrag: Défragmenter le disque
 txt_disk_management: Gestion des disques
-txt_dispaly: Afficher le résultat sous
+txt_dispaly: Afficher les résultats comme
 txt_displayedmnu_obj: affiché
 txt_displayedobjects: Objets affichés
 txt_nocompress: ne pas compresser
 txt_delete: Voulez-vous supprimer le(s) fichier(s) sélectionné(s) ? L'opération ne peut pas être annulée et les fichiers ne seront pas récupérables à partir de la corbeille
-txt_wipe: Voulez-vous vraiment supprimer le(s) fichier(s) sélectionné(s) ? L'opération ne peut pas être annulée et les fichiers ne seront pas récupérables
-txt_done: D'accord
+txt_wipe: Voulez-vous supprimer le(s) fichier(s) sélectionné(s) de mainère sécurisée ? L'opération ne peut pas être annulée et les fichiers ne seront pas récupérables
+txt_done: Terminé
 txt_edit: Éditer
 txt_elapsed: écoulé:
 txt_error_emptycl: Ligne de commande vide !
 txt_encrypt: Crypter
 txt_encrypted: crypté
 txt_encryption: Cryptage
-txt_note: Entrer une note/une description
+txt_note: Entrer une note/description
 txt_random_keys: Entrer une clef aléatoire
-txt_random_keys_hint: Entrer une clef aléatoire (que vous ne voulez pas vous rappeler)
+txt_random_keys_hint: Entrer une clef aléatoire (vous n'avez pas à vous en rappeler)
 txt_ent: Evaluation d'entropie
-txt_ent_tools: Outils d'échantillonnage d'Entropie
-txt_eqorlarger: égal ou plus grand que l'objet sélectionné
-txt_eqorrecent: égal ou plus récent que l'objet sélectionné
-txt_eqorolder: égal ou plus ancien que l'objet sélectionné
-txt_eqorsmaller: égal ou plus petit que l'objet sélectionné
-txt_equal: égal à l'objet sélectionné
-txt_erase_hint: Effacer les fichiers: écraser avec des données aléatoires, cacher leur taille, les renommer puis les supprimer définitivement
-txt_extraction_error: Erreur lors de l'extraction de l'objet sélectionné. Si l'archive est protégé par un mot de passe, indiquer-le !
-txt_exclude_hint: Exclure les fichiers, un par ligne; utiliser les caractères * et ?, les délimiteurs " et ' ne sont pas nécessaires
-txt_exclusion_recourse: Recourir à l'exclusion du filtrage des sous-répertoires
+txt_ent_tools: Déplacez la souris ou utilisez des outils d'échantillonnage d'entropie supplémentaires
+txt_eqorlarger: Identique ou plus grand que l'objet sélectionné
+txt_eqorrecent: Identique ou plus récent que l'objet sélectionné
+txt_eqorolder: Identique ou plus ancien que l'objet sélectionné
+txt_eqorsmaller: Identique ou plus petit que l'objet sélectionné
+txt_equal: Identique à l'objet sélectionné
+txt_erase_hint: Effacement sécurisé : écraser avec des données aléatoires, cacher leur taille, les renommer puis les supprimer définitivement
+txt_extraction_error: Erreur lors de l'extraction de l'objet sélectionné. Si l'archive est protégé par un mot de passe, veuillez l'indiquer
+txt_exclude_hint: Exclure le(s) fichier(s), un par ligne; utiliser les caractères * et ?, les délimiteurs " et ' ne sont pas nécessaires
+txt_exclusion_recourse: Recours aux filtres d'exclusion des sous-répertoires 
 txt_exclusion: Exclusion
 txt_exe: Exécutable
 txt_overwrite_qry: existe dans le répertoire de destination; écraser le(s) fichier(s) avec le même nom du répertoire source ? (Annuler: ignorer cette copie d'objet)
@@ -831,7 +831,7 @@ txt_caption_extract: Extraire
 txt_ext_nopath: Extraire (sans répertoire)
 txt_ext_all: Extraire tout
 txt_ext_allhere: Extraire tout ici
-txt_ext_allto: Extraire tout dans...
+txt_ext_allto: Extraire tout dans
 txt_extopen_custom: Extraire et ouvrir avec l'application personnalisée
 txt_extopen_with: Extraire et ouvrir avec...
 txt_ext_disp_here: Extraire et afficher ici
@@ -846,85 +846,85 @@ txt_newfoldermenu: Extraire dans un nouveau dossier
 txt_extto: Extraire dans...
 txt_level_fast: Rapide
 txt_fastcompr: compression rapide
-txt_fastopen: Routine d'ouverture rapide, arrêter d'examiner si la liste dépasse
+txt_fastopen: Routine d'ouverture rapide, arrête de parcourir des archives extrêmement volumineuses, utilise plutôt des filtres
 txt_level_fastest: Plus rapide
-txt_favformats: Formats favoris
+txt_favformats: Raccourci des formats favoris
 txt_file: Fichier
-txt_filebrowser: Exploration de fichiers/d'archives
-txt_filetools: Outils fichier
+txt_filebrowser: Exploration de fichiers
+txt_filetools: Outils de fichier
 txt_files: fichier(s),
 txt_nfiles: Fichiers
-txt_fs: Fichier système
+txt_fs: Système de fichiers
 txt_filters_recourse: Recourir au filtre des sous-répertoires
 txt_filters: Filtres
 txt_flat: Plat (tout afficher)
-txt_list_flat: Afficher à plat:
+txt_list_flat: Afficher à plat
 txt_unit_floppy: Disquette
 txt_foldername: Nom de dossier
 txt_nfolders: Dossiers
-txt_error_input_multi: Le format n'autorise qu'un fichier unique en Entrée; vous pouvez utiliser le commutateur  "TAR auparavant" pour enregistrer l'entrée dans une archive .TAR, vous pouvez aussi choisir un autre format. HINT: sélectionne le format de l'archive après avoir sélectionnées les données en Entrée: la commutation "TAR auparavant" sera automatiquement définie
-txt_fwd: Avancer
-txt_list_found: Recheché(s):
+txt_error_input_multi: le format n'autorise qu'un fichier unique en Entrée; vous pouvez cocher "TAR auparavant" pour enregistrer l'entrée dans une archive .TAR, vous pouvez aussi choisir un autre format. Astuce : sélectionne le format de l'archive après avoir sélectionné les données en entrée: la case "TAR auparavant" sera automatiquement cochée
+txt_fwd: Suivant
+txt_list_found: Trouvé(s)
 txt_free: Libre
-txt_free2: Libre
+txt_free2: libre
 txt_name_full: Nom complet
 txt_function: Fonction
 txt_general: Général
-txt_multithreading: Multitaches génériques
+txt_multithreading: Multithreading générique
 txt_go_browser: Aller à l'explorateur de fichiers
-txt_go_path: Aller au répertoire des objets
+txt_go_path: Explorer le chemin (PeaZip)
 txt_guicl: Graphique + console
-txt_guipealauncher: GUI installé par PeaLauncher
+txt_guipealauncher: Graphique : enveloppé par PeaLauncher
 txt_graphic: Dossier graphique
-txt_gridaltcolor: Grilles de couleurs alternées
+txt_gridaltcolor: Grille de couleurs alternative
 txt_gridrowheight: Hauteur des lignes des grilles
-txt_gui: GUI
+txt_gui: Interface graphique
 txt_type_description_gzip: GZip: compression rapide
 txt_here: ici
 txt_list_history: Historique
-txt_homeroot: Ordinateur/racine du niveau des Archives
+txt_homeroot: Niveau racine de l'ordinateur/archive
 txt_quickbrowse_hint: Si la navigation est arrêté, l'utilisateur peut limiter la sélection en utilisant les fonctions de filtre ou de recherche; extraction/liste et test ne sont pas affectés.
-txt_backupexe_hint: Si quelque chose ne va pas et abouti à un résultat non fonctionnel, vous pouvez récupérer l'exécutable original de la copie de sauvegarde automatique
-txt_attach: Si votre messagerie supporte cette commande, l'archive sera joint au nouvel email
+txt_backupexe_hint: Si quelque chose ne va pas et abouti à un résultat non fonctionnel, vous pouvez récupérer l'exécutable original depuis la copie de sauvegarde automatique
+txt_attach: Si votre messagerie supporte cette commande, l'archive sera jointe au nouvel email
 txt_images: Images
 txt_include_hint: Inclure des fichiers, un par ligne; utiliser les caractères * et ?, les délimiteurs " et ' ne sont pas nécessaires
-txt_filters_hint: Inclusion et exclusion des filtres pour 7z binaire, liser attentivement la documentation 7-Zip pour comprendre comment ces filtres fonctionnent
+txt_filters_hint: Filtres d'inclusion et d'exclusion pour le binaire 7z, liser attentivement la documentation 7-Zip pour comprendre comment ces filtres fonctionnent
 txt_inclusion_recourse: Recours aux filtres d'inclusion des sous-répertoires
-txt_inclusion: Inclusion:
+txt_inclusion: Inclusion
 txt_error_function: Fonction demandée incorrecte
 txt_info: Info
 txt_infoall: Info sur tout
 txt_infodisp: Info sur les objets affichés
 txt_infosel: Info sur les objets sélectionnés
-txt_inputinfo: Info entrée
+txt_inputinfo: Info d'entrée
 txt_input_list: Liste d'entrée:
 txt_iop: entrée, destination, paramètres
 txt_ipo: entrée, paramètres, destination
-txt_input: entrée:
+txt_input: Entrée
 txt_integrity: Vérifier l'intégrité
 txt_chunk_size: Taille personnalisée incorrecte, veuiller la corriger en une valeur numérique
 txt_invertsel: Inverser la sélection
-txt_type_exe: est un exécutable de Windows, voulez-vous l'exécuter ? (Ne pas l'ouvrir dans l'explorateur d'archives de PeaZip; seuls les programmes NSIS, SFX 7-Zip et .MSI peuvent l'explorer de cette façon)
-txt_return_to_archive: est déjà ouvert; voulez-vous l'exporer ?
+txt_type_exe: est un exécutable Windows, voulez-vous l'exécuter ? ("Non" pour essayer de l'ouvrir en tant qu'archive) Astuce : certains exécutables peuvent ne pas fonctionner correctement à moins que l'intégralité de l'archive ne soit extraite avant
+txt_return_to_archive: est déjà ouvert; voulez-vous l'explorer ?
 txt_not_accessible: n'est plus accessible
-txt_type_unsupported: n'est pas pris en archive, taper
+txt_type_unsupported: n'est pas un type d'archive pris en charge
 txt_checkname_failed: n'est pas un nom valide.
 txt_not_accessible_list: est inaccessible, veuillez vérifier si la liste des fichiers fournis est exacte et à jour
-txt_theme_create_error: Il n'a pas été possible de créer le thème, essayez d'utiliser un nom valide pour un dossier en tant que  nom de thème et sélectionner un répertoire d'accès en lecture
-txt_theme_exists: jet existe, indiquer un répertoire différent
-txt_job_code: code de travail:
-txt_job_definition_saved: Définition du travail enregistrée sous
-txt_job_success: Travail terminé avec succès !
+txt_theme_create_error: Il n'a pas été possible de créer le thème, essayez d'utiliser un nom valide pour un dossier en tant que nom de thème et sélectionnez un répertoire d'accès en lecture
+txt_theme_exists: existe encore, veuillez fournir un chemin différent
+txt_job_code: code de tâche :
+txt_job_definition_saved: Définition du travail enregistrée dans
+txt_job_success: Tâche terminée avec succès !
 txt_join: Joindre
 txt_joinfiles: Joindre des fichiers
 txt_keyfile: Fichier clef
 txt_keyfile_not_found: Le fichier clef est introuvable ou ne peut être lu. Veuillez choisir un autre fichier clef.
 txt_keyfile_notcreated: Fichier clef non créé
-txt_larger: plus grand que l'objet sélectionné
+txt_larger: Plus grand que l'objet sélectionné
 txt_lastused: Dernière utilisation
 txt_launch: Démarrer la tâche
 txt_layout: Disposition
-txt_filelist_savedas: Mise en page enregistrée sous
+txt_filelist_savedas: Disposition enregistrée sous
 txt_level: Niveau
 txt_license: Licence
 txt_caption_list: Liste
@@ -932,24 +932,24 @@ txt_list_details: Liste (avec détails)
 txt_list_all: Tout lister
 txt_list_disp: Liste des objets affichés
 txt_list_sel: Liste des objets sélectionnés
-txt_toggle_warning: Lister d'afficher à plat des répertoires du contenu peu prendre beaucoup de temps, continuer quand même ?
+txt_toggle_warning: L'affichage à plat du contenu du chemin peut prendre beaucoup de temps, continuer quand même ?
 txt_loadfile: Charger le fichier
-txt_loadlayout: Charger le fichier
-txt_unit_hd: Disque Local
+txt_loadlayout: Charger la disposition
+txt_unit_hd: Disque local
 txt_localization: Langue
 txt_lpaqver: Version LPAQ
 txt_type_description_lpaq: LPAQ: version rapide de PAQ, très bonne compression
 txt_maininterface: Interface principale
 txt_maxcomp: Mode de compression max.
-txt_level_maximum: Maximale
+txt_level_maximum: Maximal
 txt_restartrequired: Il sera peut-être nécessaire de redémarrer l'application pour être appliquée
-txt_required_memory: Mo de mémoire nécessaire
+txt_required_memory: MB de mémoire nécessaire
 txt_method: Méthode
 txt_misc: Divers
 txt_modify: Modifier
 txt_morecontrols: Plus de contrôles (historique, favoris...)
-txt_morerecent: plus récent que l'objet sélectionné
-txt_ent_hint: Déplacer la souris, entrer les clés dans le champ d'édition, charger les fichiers pour recueillir l'entropie du système...
+txt_morerecent: Plus récent que l'objet sélectionné
+txt_ent_hint: Déplacer la souris, entrer les clés dans le champ d'édition, charger les fichiers pour collecter l'entropie du système...
 txt_moveto: Déplacer dans...
 txt_mypc: Racine de l'ordinateur
 txt_list_na: n/a
@@ -958,35 +958,35 @@ txt_naming: Politique de renommage
 txt_unit_remote: Lecteur réseau
 txt_newarchive: Nouvelle archive
 txt_cnewfolder: Nouveau dossier
-txt_news: Nouvelles
+txt_news: Actualités
 txt_no: Non
 txt_noinput: Entrée reçue inaccessible
 txt_nocompress_hint: aucune compression (plus rapide)
 txt_split_noinput: Aucune entrée sélectionnée; veuillez sélectionner un fichier à scinder
-txt_open_noinput: Aucune entrée sélectionnée; veuillez sélectionner une archive (volume de premières archives pour archives multi-volume)
+txt_open_noinput: Aucune entrée sélectionnée; veuillez sélectionner une archive (uniquement le premier volume pour archives multi-volume)
 txt_list_nomatch: aucune correspondance
-txt_singlethread: pas de multitaches
-txt_none2: aucune
+txt_singlethread: pas de multitâche
+txt_none2: aucun
 txt_nonsolid: Non-solide
-txt_level_normal: normal
+txt_level_normal: Normal
 txt_copy_error: n'a pas été copié ou déplacé avec succès, code d'erreur:
 txt_description: Notes/description
 txt_compare_second: Sélectionner le fichier à comparer
-txt_peaobj: Contrôle de l'Objet
+txt_peaobj: Contrôle de l'objet
 txt_displayed_obj: objet(s)
 txt_olderthan: plus ancien que l'objet sélectionné
-txt_on: sur
+txt_on: activé
 txt_ondblclick: Lors d'un double-clic:
 txt_opacity: Opacité
 txt_open: Ouvrir
 txt_openarchive: Ouvrir une archive
 txt_title_open: Ouvrir, décrypter ou joindre une archive...
-txt_open_bookmark: Ouvrir un favoris
+txt_open_bookmark: Ouvrir un favori
 txt_cphere: Ouvrir une invite de commande ici
 txt_open_file: Ouvrir un fichier
 txt_open_files: Ouvrir le(s) fichier(s)
-txt_open_path: Ouvrir le répertoire
-txt_opensource: Logiciel de compression open source
+txt_open_path: Ouvrir un répertoire
+txt_opensource: Logiciel de compression portable open source
 txt_openwith: Ouvrir avec...
 txt_aborted: Opération annulée
 txt_unit_cd: Disque optique
@@ -1003,22 +1003,22 @@ txt_type_description_paq: PAQ: lent, mais compression extrèmement puissante
 txt_pio: paramètres, entrée, destination
 txt_poi: paramètres, destination, entrée
 txt_parameters: Paramètres:
-txt_error_partial: Extraction partielle non mise en oeuvre pour le type d'archives actuel
+txt_error_partial: Extraction partielle non implémentée pour le type d'archives actuel
 txt_passes: Passes
 txt_pw: Mot de passe
 txt_pwlength: Longueur en caractères du mot de passe (4..64)
 txt_un7z_browse_pw: mot de passe requis
 txt_un7z_browse_pw_other: le mot de passe est invalide
-txt_paste: Coller (Ctrl+V)
-txt_path: Répertoire:
+txt_paste: Coller
+txt_path: Chemin
 txt_pea_appcolor: Couleur de l'application
 txt_pea_textcolor: Couleur du texte
 txt_type_description_pea: PEA: axé sur la sûreté du format de l'archive avec une compression rapide
 txt_peazip_new: PeaZip (nouvelle instance)
 txt_peazip_help: Support en ligne
-txt_peazip_web: Site Web du projet de PeaZip
-txt_performall: Effectuer tous les algorithmes supportés
-txt_name_provide: Eviter les caractères \ /: * ? ' " < > |
+txt_peazip_web: Site Web de PeaZip
+txt_performall: Tous les algorithmes
+txt_name_provide: Les caractères \ / : * ? ' " < > | ne sont pas autorisés dans les noms de fichiers
 txt_upxorstrip: Sélectionner Strip et/ou UPX en binaire
 txt_not_removable_file: Fermer le fichier en cours pour que PeaZip puisse le supprimer:
 txt_not_removable: Fermer les fichiers en cours pour que PeaZip puisse supprimer le dossier:
@@ -1030,87 +1030,87 @@ txt_copy_wait: Veuiller attendre la fin de la planification prévue pour les op�
 txt_previewwith: Prévisualiser avec...
 txt_projectadmin: Administrateur de projet:
 txt_type_description_quad: BALZ/QUAD: haute performance à base de compresseur de fichiers ROLZ
-txt_quickdelete: Effacer rapidement
+txt_quickdelete: Suppression rapide
 txt_quit: Quitter
 txt_unit_ram: Disque RAM
 txt_read: Lecture:
 txt_recentarchives: Archives récentes   
 txt_rr_hint: Récupération de rapports permet d'essayer de corriger les archives en cas de corruption de données
 txt_search_refine: Affiner le filtre de recherche, accepte les caractères ? et *
-txt_fefreshf5: Actualiser (F5)
+txt_fefreshf5: Actualiser
 txt_release: version:
 txt_unit_removable: Unité amovible
-txt_remove_bookmark: Supprimer le signet
-txt_remove_external_unit: Supprimer les unités externes
-txt_removeselected: Supprimer les objets sélectionnés
+txt_remove_bookmark: Supprimer le favori
+txt_remove_external_unit: Supprimer le(s) périphérique(s) externe(s)
+txt_removeselected: Supprimer le(s) objet(s) sélectionnés
 txt_rename: Renommer
 txt_caption_repair: Réparer
 txt_restartrequired2: nécessite le redémarrage de l'application
-txt_reset: Reinitialiser
-txt_reset_archivename: Reinitialiser le nom de l'archive
-txt_hardreset: Reinitialiser le favoris
-txt_reset_theme: Reinitialiser les thèmes
+txt_reset: Réinitialiser
+txt_reset_archivename: Réinitialiser le nom de l'archive
+txt_hardreset: Réinitialiser les favoris
+txt_reset_theme: Réinitialiser les thèmes
 txt_restore_att: restaurer les attributs originaux
-txt_run_as: Exécuter sous (impossible de basculer à des utilisateurs avec un mot de passe vide)
+txt_run_as: Exécuter en tant que (impossible de basculer à des utilisateurs avec un mot de passe vide)
 txt_run_as2: Exécuter avec un utilisateur différent
 txt_sample: Modèle: 
 txt_saveas: Enregistrer sous
-txt_savehistory: Enregistrer l'historique de la dernière archive utilisée
+txt_savehistory: Enregistrer les données de l'historique
 txt_save_infolder: Enregistrer dans un dossier (auto)
 txt_savejob: Enregistrer le travail
 txt_savejobdefinition: Enregistrer la définition du travail
-txt_savejobdefinition_hint: Enregistrer la définition du travail en tant que texte brut, vous pouvez l'utiliser à partir de vos scripts
-txt_savelayout: Sauver la disposition
+txt_savejobdefinition_hint: Enregistrer la définition du travail en tant que texte brut; vous pouvez l'utiliser à partir de vos scripts
+txt_savelayout: Enregistrer la disposition
 txt_save_winstate: Enregistrer l'état de la fenêtre principale
-txt_search: La recherche peut prendre un peu de temps
+txt_search: Recherche (récursive, peut prendre un certain temps)
 txt_searchanddrag: Rechercher et glisser ici
-txt_searchfor: Rechercher:
-txt_nrsearch: Rechercher ici (non recursive)
-txt_search_hint: Rechercher dans les sous-répertoires des archives pour correspondre aux filtres
+txt_searchfor: Rechercher
+txt_nrsearch: Rechercher ici (non recursif)
+txt_search_hint: Rechercher dans les sous-répertoires de l'archive les correspondances avec le(s) filtre(s)
 txt_search_web: Rechercher sur le web
 txt_list_searching: Recherche...
-txt_securedelete: Suppression le(s) (fichiers)
-txt_default_description: Sélectionner une fonction ou glisser les fichiers ici
-txt_selectall: Sélectionner tous
+txt_securedelete: Suppression sécurisée
+txt_default_description: Sélectionner une fonction ou glissez les fichiers ici
+txt_selectall: Tout sélectionner
 txt_selectdir: Sélectionner un répertoire
 txt_selected_obj: sélectionné
 txt_selected_objects: Objets sélectionnés
 txt_sfx: Auto-extractible
-txt_sendbymail: Envoyer par e-mail (si supporté)
-txt_set_defaults: Paramètres par défaut
+txt_sendbymail: Envoyer par e-mail
+txt_set_defaults: Définir les paramètres par défaut de l'application
 txt_settings: Paramètres
 txt_sfx_interface: Interface sfx
-txt_showhints: Afficher les conseils
+txt_showhints: Afficher les astuces
 txt_show_messages: Afficher les messages d'information
-txt_showpw: Afficher le champs du contenu du mot de passe
-txt_singlevol: Volume unique
+txt_showpw: Afficher le contenu du champ de mot de passe
+txt_singlevol: Volume unique, ne pas scinder
 txt_size: Taille
-txt_sizeb: Taille (O)
+txt_sizeb: Taille (Bytes)
 txt_skip_existing: Ignorer les fichiers existants
 txt_slowercomp: compression plus lente mais décompression tout aussi rapide
-txt_smaller: plus petit que l'objet sélectionné
+txt_smaller: Plus petit que l'objet sélectionné
 txt_solid: Solide
 txt_solid_block: Bloc solide
-txt_solid_auto: Solide, ajustement auto.
-txt_solid_extension: Solide, groupe par extension
-txt_listtest: Désolé, l'opération de test de liste/fonctionnement n'est pas mis en oeuvre pour ce format
+txt_solid_auto: Solide, ajustement automatique
+txt_solid_extension: Solide, regroupement par extension
+txt_listtest: désolé, l'opération liste/test n'est pas encore implémentée pour ce format
 txt_sortbysel: Trier par l'état de sélection
 txt_list_sorting: Tri...
 txt_speed: vitesse
 txt_split: Scinder
 txt_type_description_split: Scinder un fichier avec l'option de contrôle d'intégrité
 txt_split_file: Scinder le fichier
-txt_list_nostats: Statistiques non disponibles
+txt_list_nostats: statistiques non disponibles
 txt_status: Statut
-txt_level_store: stocker
+txt_level_store: Stocker
 txt_stream_control: Contrôle du flux
 txt_strip: Strip avant UPX (recommandé)
-txt_keyfile_created: A été créé avec succès en tant que fichier clef sous:
-txt_suggestpw: Suggérer un mot de passe
-txt_noupx: Symboles dépouillé, pas de compression UPX
+txt_keyfile_created: Fichier crée en tant que :
+txt_suggestpw: Créer un mot de passe aléatoire
+txt_noupx: Symboles supprimés, pas de compression UPX
 txt_syntax: Syntaxe:
-txt_sysbenchmark: Test du Système
-txt_benchmark: Le test du système prendra quelques minutes et utilisera toute l'UC et la mémoire disponible. Le système ne peut pas répondre pendant le test; voulez-vous continuer ?
+txt_sysbenchmark: Test du système
+txt_benchmark: Le test du système prendra quelques minutes et utilisera toute le processeur et la mémoire disponible. Le système peut ne pas répondre pendant le test; voulez-vous continuer ?
 txt_systools: Outils système
 txt_tarbefore: TAR auparavant
 txt_type_description_tar: TAR: format d'archivage principal sur les systèmes UNIX
@@ -1118,101 +1118,101 @@ txt_taskman: Gestionnaire de tâches
 txt_caption_test: Tester
 txt_testall: Tout tester
 txt_testdisp: Tester le(s) objet(s) affiché(s)
-txt_testpw: Tester le mot de passe/le fichier clef
+txt_testpw: Tester le mot de passe/fichier clef
 txt_testsel: Tester le(s) objet(s) sélectionné(s)
 txt_col_hint: La couleur doit être choisie de manière à bien s'intégrer avec les couleurs de l'icône et aux autres éléments de l'interface graphique
-txt_bookmarks_hint: La liste complète et éditable de signets est disponible dans l'interface de navigateur de fichiers, cliquer sur l'icône "Plus de contrôles" et sur "Historique/signets"
-txt_archive_noinput_tolist: La mise en page est vide: utiliser l'outil Ajouter un fichier, Ajouter un dossier ou charger
+txt_bookmarks_hint: La liste complète et éditable de favoris est disponible dans l'interface de navigateur de fichiers, cliquer sur l'icône "Plus de contrôles" et sur "Historique/Favoris"
+txt_archive_noinput_tolist: La disposition est vide : veuillez utiliser Ajouter fichier(s), Ajouter dossier(s) ou Charger la disposition pour remplir la disposition de l'archive
 txt_theme: Thème
 txt_icons_found: Thème chargé avec succès.
 txt_themename: Nom du thème
-txt_icons_not_found: Thème pas chargé correctement. Essayer de passer au thème par défaut ou à un thème connu qui fonctionne.
+txt_icons_not_found: Le thème n'a pas été chargé correctement. Essayer de passer au thème par défaut ou à un thème qui fonctionne.
 txt_theme_create_success: thème créé avec succès dans
 txt_theming: Personnalisation
 txt_extand_error: Cette fonction peut être effectuée que sur un seul objet à la fois
-txt_threads: Taches
+txt_threads: Tâches
 txt_titlescolor: Couleur des titres
-txt_to: à
-txt_toggle_browseflat: Exploration/Afficher à plat
-txt_toggle_historybookmarks: Historique et favoris
+txt_to: vers
+txt_toggle_browseflat: Navigation/la vue à plat (afficher tout)
+txt_toggle_historybookmarks: Barre de statut, historique, favoris, presse-papiers
 txt_toolbarscolor: Couleur de la barre d'outils
 txt_tools: Outils
 txt_best: essayer les meilleurs réglages (lent)
 txt_type: Type
 txt_level_ultra: ultra
 txt_error_openfile: Impossible d'ouvrir le fichier spécifié
-txt_cl_hint: UPX et UnAce sont toujours lancés en mode console; le travail de liste, test et comparaison  en mode graphique
-txt_ace_missing: Le plugin UnAce est manquant; pour le traitement des archives ACE, vous pouvez télécharger la forme de plugin de PeaZip sur son site Web (UnAce est une source fermée, le plugin n'est pas présente dans le pack de Base)
+txt_cl_hint: UPX et UnAce sont toujours lancés en mode console; le travail de liste, test et comparaison sont toujours lancés en mode graphique
+txt_ace_missing: Le plugin UnAce est manquant; pour le traitement des archives ACE, vous pouvez télécharger le plugin de PeaZip sur son site Web (UnAce est une source fermée, le plugin n'est pas présent dans le pack de base)
 txt_units: unités
 txt_unit_unknown: Type de disque inconnu
 txt_un7z_pw_untested: Non testé
-txt_up: Afficher
-txt_update: mise à jour (si l'archive existe)
-txt_type_description_upx: UPX: compression d'exécutable seulement
+txt_up: Haut
+txt_update: Mise à jour (si l'archive existe)
+txt_type_description_upx: UPX: compression d'exécutables seulement
 txt_advfilters: Utiliser les filtres avancés
 txt_openfiles_hint: Utiliser cette option pour inclure dans l'archive des fichiers ouvert en écriture par d'autres applications (utile dans des travaux de sauvegarde)
 txt_usenet: Usenet
 txt_user_name: Nom; utiliser la forme utilisateur@DOMAINE ou DOMAINE\utilisateur si nécessaire.
-txt_using: Utiliser:
-txt_volumepea: Contrôle du Volume
-txt_volume_size: Taille du Volume
+txt_using: Utilisant :
+txt_volumepea: Contrôle du volume
+txt_volume_size: Taille du volume
 txt_type_ext_uns: a été extrait avec succès
 txt_websearch: Recherche sur le Web
-txt_websites: Site Web
+txt_websites: Sites Web
 txt_word: Mot
-txt_write: Écriture:
+txt_write: Écriture :
 txt_ramdompw_hint: Vous pouvez copier le mot de passe aléatoire généré à partir d'ici
-txt_exe_hint: Vous pouvez entrer le nom de l'exécutable nom et les paramètres de compression personnalisés et choisir la syntaxe de la contruction. Noter que vous pouvez également modifier manuellement la syntaxe de commande dans l'onglet "Console".
-txt_pj_hint2: Vous pouvez importer la définition du travail de l'interface dans le champ mémo ci-dessous. Ensuite, vous pouvez modifier, lancer, mettre sans modifier ou perdre le travail défini pour l'interface frontend.
-txt_type_description_zip: ZIP: format d'archivage/compression rapide, intégrer sur les systèmes Windows
-txt_zipcrypto_hint: ZipCrypto (héritage)
+txt_exe_hint: Vous pouvez entrer le nom de l'exécutable nom et les paramètres de compression personnalisés et choisir la syntaxe de la contruction. Notez que vous pouvez également modifier manuellement la syntaxe de commande dans l'onglet "Console".
+txt_pj_hint2: Vous pouvez importer la définition du travail de l'interface graphique dans le champ mémo ci-dessous. Ensuite, vous pouvez modifier, lancer ou sauvegarder sans modifier ou perdre le travail défini pour l'interface graphique.
+txt_type_description_zip: ZIP: format d'archivage/compression rapide, populaire sur les systèmes Windows
+txt_zipcrypto_hint: ZipCrypto (hérité)
 
 === end PeaZip text group ===
 
 === PeaLauncher text group ===
 
 txt_6_9_remaining: restant
-txt_6_5_abort: Abandonner
+txt_6_5_abort: Arrêter
 txt_6_5_error: Erreur
 txt_6_5_no: Non
 txt_6_5_warning: Attention
 txt_6_5_yes: Oui
-txt_6_5_yesall: Oui à tous
-txt_5_6_update: Vérifier les mises à jour
-txt_5_6_cml: Langue du menu contexte système
+txt_6_5_yesall: Oui à tout
+txt_5_6_update: Chercher des mises à jour
+txt_5_6_cml: Langue du menu contextuel système
 txt_5_6_donations: Dons
-txt_5_6_localization: Localisation
+txt_5_6_localization: Traduction
 txt_5_6_runasadmin: Exécuter en tant qu'administrateur
-txt_5_6_help: Support
-txt_5_5_cancelall: Annuler tous
+txt_5_6_help: Support en ligne
+txt_5_5_cancelall: Tout annuler
 txt_5_3_details: Détails
 txt_5_3_files: fichiers
 txt_5_3_folders: dossiers
 txt_5_3_info: Info
 txt_5_3_list: Liste
 txt_5_3_os: Taille d'origine
-txt_5_3_ps: Dimensions emballée
+txt_5_3_ps: Taille compressée
 txt_5_3_test: Tester
-txt_5_0_extract: Extrait
+txt_5_0_extract: Extraire
 txt_5_0_from: de
 txt_5_0_in: dans
-txt_5_0_to: à
+txt_5_0_to: vers
 txt_4_5_search: Recherche
-txt_4_0_drag: Glisser ici l'archive à extraire, ou 
+txt_4_0_drag: Faites glisser ici l'archive à extraire, ou 
 txt_4_0_dragorselect: Faites glisser ici ou sélectionner un fichier
-txt_4_0_select: sélectionner le fichier
-txt_3_6_selectdir: Sélectionner le répertoire
+txt_4_0_select: sélectionner un fichier
+txt_3_6_selectdir: Sélectionner un répertoire
 txt_3_5_close: Fermer
-txt_3_0_details: Pour plus de détails mode, "Rapport" contient le journal de l'emploi, et "Console" contient la définition de travail en ligne de commande
-txt_3_0_hints: Conseils sur l'erreur
-txt_3_0_arc: Impossible de lire certains fichiers d'entrée (peut être verrouillée, pas accessibles ou endommagé)
+txt_3_0_details: Pour plus de détails, veuillez consulter l'onglet "Rapport" pour le journal complet de la tâche et l'onglet "Console" pour la définition de la tâche en ligne de commande.
+txt_3_0_hints: Indices sur l'erreur
+txt_3_0_arc: Les causes possibles de l'erreur peuvent être des fichiers d'entrée non lisibles (verrouillés, inaccessibles, corrompus, volumes manquants dans l'archive en plusieurs parties...), ou un chemin de sortie complet ou non accessible.
 txt_3_0_ext: L'archive peut exiger un mot de passe différent pour l'opération en cours
-txt_2_8_oop: Ouvrir la sortie lorsque la tâche est terminée
-txt_2_7_validatefn: Operation stoppée pour cause de nom de fichier invalide:
-txt_2_7_validatecl: Operation stoppée car la commande est potentiellement dangereuse (i.e. concatenation de commandes non autorisée par le programme ):
+txt_2_8_oop: Ouvrir le répertoire de destination lorsque la tâche est terminée
+txt_2_7_validatefn: Operation stoppée pour cause de nom de fichier invalide :
+txt_2_7_validatecl: Operation stoppée car la commande est potentiellement dangereuse (par exemple concatenation de commandes non autorisée par le programme):
 txt_2_6_open: Ouvrir une archive
 txt_2_5_ace_missing: Le plugin UNACE est manquant ; pour utiliser les archives ACE, vous pouvez télécharger ce plugin depuis le site de PeaZip (Ce plugin n'étant pas open source, il n'est pas inclus dans l'installation basique)
-txt_2_3_pw_errorchar_gwrap:: Ce caractère ne peut pas être utilisé par PeaLauncher pour les mots de passe avec cet OS, modifier le mot de passe ou choisisser le mode Console dans Outils > Paramètres
+txt_2_3_pw_errorchar_gwrap: le guillemet ne peut pas être utilisé par PeaLauncher dans les mots de passe sous le système actuel, veuillez changer le mot de passe ou choisir le mode console dans l'interface utilisateur des binaires backend dans Options > Paramètres
 txt_2_3_renameexisting: Renommer automatiquement les fichiers existants
 txt_2_3_renameextracted: Renommer automatiquement les fichiers extraits
 txt_2_3_cancel: Annuler
@@ -1221,72 +1221,72 @@ txt_2_3_extinnew: Extraire dans un nouveau dossier
 txt_2_3_keyfile: Fichier clef
 txt_2_3_kf_not_found_gwrap: Le fichier clef est introuvable ou ne peut pas être lu. Sélectionnez un autre fichier clef.
 txt_2_3_moreoptions: Plus d'options...
-txt_2_3_nopaths: Pas de répertoire
+txt_2_3_nopaths: Pas de chemin
 txt_2_3_options: Options
 txt_2_3_overexisting: Écraser les fichiers existants
 txt_2_3_pw: Mot de passe
 txt_2_3_skipexisting: Ignorer les fichiers existants
-txt_job_unknown:: Erreur inconnue
-txt_stdjob: [l'animation s'arrêtera et un PopUp apparaitra à la fin]
+txt_job_unknown: Erreur inconnue
+txt_stdjob: [l'animation s'arrêtera à la fin de la tâche]
 txt_benchmarkjob: [le système répondra lentement lors de l'exécution du test (quelques minutes)]
-txt_defragjob: [aucune réponse pendnat la défragmentation, vous pouvez la laisser fonctionner en arrière-plan]
+txt_defragjob: [aucune réponse pendant la défragmentation, vous pouvez la laisser fonctionner en arrière-plan]
 txt_consolejob: [vous pouvez voir le détail de la progression dans la fenêtre de la console]
-txt_job1: 1: Attention: ce ne sont pas des erreurs fatales, mais certains fichiers sont manquants ou bloqués
+txt_job1: 1: Attention: erreurs non-fatales, par exemple certains fichiers sont manquants ou bloqués
 txt_job127: 127: Impossible d'exécuter l'opération demandée
 txt_job2: 2: Erreur fatale
-txt_job255: 255: travail interrompue par l'utilisateur
+txt_job255: 255: Tâche interrompue par l'utilisateur
 txt_job7: 7: Erreur: ligne de commande incorrecte
 txt_job8: 8: Erreur: pas assez de mémoire pour l'opération demandée
-txt_autoclose: Fermer cette fenêtre lorsque ce travail est terminé
-txt_crscale: Taux de Compression (lent, meilleur):
+txt_autoclose: Fermer cette fenêtre lorsque la tâche est terminée
+txt_crscale: Taux de compression (lent, meilleur):
 txt_console: Console
-txt_benchscale: Évaluation Core 2 Duo 6600, équivalent de vitesse MHz.
+txt_benchscale: Core 2 Duo 6600, vitesse équivalente en MHz.
 txt_create: Créer
-txt_done: Accepter:
+txt_done: Terminé :
 txt_nocl: Ligne de commande vide
-txt_error: Erreur:
+txt_error: Erreur :
 txt_explore: Explorer
 txt_extto: Extraire dans
-txt_halt: Arrêter le système lorsque le travail est terminé
-txt_halted: Arrété:
-txt_hardware: Matériel
+txt_halt: Arrêter le système lorsque la tâche est terminé
+txt_halted: Arrété :
+txt_hardware: matériel
 txt_high: Priorité haute
 txt_idle: Priorité inoccupée
-txt_input: Entrée:
-txt_jpaused: Travail en pause
-txt_jresumed: Reprise du travail
-txt_job_started: Lancement du travail
-txt_jobstatus: Statut de la tâche:
-txt_jstopped: Travail arrété par l'utilisateur
-txt_jobstopped: Le travail a été arrêté par l'utilisateur, vous pouvez voir les résultats partiels en cliquant sur le bouton "Explorer" ou lire le rapport
+txt_input: Entrée :
+txt_jpaused: Tâche en pause
+txt_jresumed: Reprise de la tâche
+txt_job_started: Lancement de la tâche
+txt_jobstatus: Statut de la tâche :
+txt_jstopped: Tâche arrétée par l'utilisateur
+txt_jobstopped: La tâche a été arrêtée par l'utilisateur; vous pouvez inspecter le résultat partiel en cliquant sur le lien du chemin de sortie.
 txt_job_success: Terminé avec succès
 txt_lt: Liste/tester
 txt_normal: Priorité normale
 txt_ok: OK
-txt_output: Destination:
+txt_output: Destination :
 txt_pause: Pause
-txt_paused: en pause,
-txt_p_high: Priorité haute
-txt_p_idle: Priorité inoccupée
-txt_p_normal: Priorité normale
-txt_p_realtime: Priorité temps réel
-txt_rating: Évaluation:
-txt_rt: Priorité en temps réel
+txt_paused: En pause,
+txt_p_high: Priorité définie sur haute
+txt_p_idle: Priorité définie sur inoccupée
+txt_p_normal: Priorité définie sur normale
+txt_p_realtime: Priorité définie sur temps réel
+txt_rating: Évaluation :
+txt_rt: priorité en temps réel
 txt_report: Rapport
 txt_resume: Continuer
-txt_priority: Clic droit pour voir les priorités
-txt_running: en cours d'exécution,
+txt_priority: Cliquez pour définir la priorité de la tâche
+txt_running: En cours d'exécution,
 txt_isrunning: En cours d'exécution...
 txt_saveas: Enregistrer sous
-txt_savejob: Enregistrer la définition du travail (inclure le mot de passe !)
-txt_savelog: Enregistrer le rapport
-txt_software: Logiciel
+txt_savejob: Enregistrer la définition de la tâche en tant que script
+txt_savelog: Enregistrer le rapport de la tâche
+txt_software: logiciel
 txt_speedscale: Vitesse, échelle logarithmique (plus élevée, meilleure):
 txt_status: Statut
 txt_stop: Arrêter
 txt_bench: Test du système
-txt_threads: Taches:
-txt_time: Temps:
+txt_threads: Fils :
+txt_time: Temps :
 
 === end PeaLauncher text group ===
 


### PR DESCRIPTION
### Changes :

- [x] **Complete rework of the French translate**
- [x] `txt_6_6_pdupfound`, `txt_2_9_test_pw2G`, `txt_2_3_pw_errorchar`, `txt_7z_exitcodeunknown`, `txt_2_3_pw_errorchar_gwrap`, `txt_job_unknown` are again available
- [x] Every single line is translated/enhanced (i.e. `txt_6_5_showvolatile` wasn't)
- [x] Fixed all grammar and conjugation errors
- [x] Fixed every typo
- [x] Translation more accurate with the App context
- [x] Simplified some strings that overlapped/were very long/were meaningless
- [x] `txt_autoclose`, `txt_savejob`, `txt_solid_block` were kept to the old translation because I can't understand the original meaning (the one in default seems not to have the meaning of its name)
- [x] `txt_upxorstrip`, `txt_strip` : `Strip` haven't been translated
- [x] Fixed inconsistencies (in words used, or in lowercase/uppercase use i.e.)
- [ ] The About section haven't been changed
- [ ] Haven't been tested, dunno how to do it

*English part*
- [x] `txt_cl_hint` typo in default : form instead of from