### PR TITLE
Add qt6 widgetset supprt

### DIFF
--- a/packages/metadarkstyle-main/src/umetadarkstyle.pas
+++ b/packages/metadarkstyle-main/src/umetadarkstyle.pas
@@ -8,7 +8,7 @@ interface
 
 {$IFDEF WINDOWS}
 uses
-    {IF DEFINED(LCLQT5)}
+    {IF DEFINED(LCLQT5) OR DEFINED(LCLQT6)}
       uDarkStyle,
     {ENDIF}
     uDarkStyleParams,

--- a/peazip-sources/dev/metadarkstyle/src/umetadarkstyle.pas
+++ b/peazip-sources/dev/metadarkstyle/src/umetadarkstyle.pas
@@ -8,7 +8,7 @@ interface
 
 {$IFDEF WINDOWS}
 uses
-    {IF DEFINED(LCLQT5)}
+    {IF DEFINED(LCLQT5) OR DEFINED(LCLQT6)}
       uDarkStyle,
     {ENDIF}
     uDarkStyleParams,

--- a/peazip-sources/dev/peach.pas
+++ b/peazip-sources/dev/peach.pas
@@ -58268,7 +58268,7 @@ end;
 
 procedure set_rowselect;
 begin
-{$IFDEF LCLQT5}rowselect:=true;{$ENDIF}//workaround, deselecting first subitem in listview does not deselect the row in Qt5, which leads to behavior of the component which is not consistent with oter widget.sets
+{$IF DEFINED(LCLQT5) OR DEFINED(LCLQT6)}rowselect:=true;{$ENDIF}//workaround, deselecting first subitem in listview does not deselect the row in Qt5, which leads to behavior of the component which is not consistent with oter widget.sets
 Form_peach.ListView1.Rowselect:=rowselect;
 Form_peach.mrowselect.checked:=rowselect;
 Form_peach.pmrow.checked:=rowselect;
@@ -75297,7 +75297,7 @@ begin
    //Qt4 and Qt5 the workaround is disabled as with tested Lazarus/PFC versions it crashes chaging at runtime back to vsReport (which is default visual style), this bug also breaks changing visual style back to default vsReport at runtime for Qt versions
    {$IFDEF LCLQT}
    {$ELSE}
-      {$IFDEF LCLQT5}
+      {$IF DEFINED(LCLQT5) OR DEFINED(LCLQT6)}
       {$ELSE}
       Form_peach.ListView1.ViewStyle:=vsIcon;
       {$ENDIF}

--- a/peazip-sources/dev/peach.pas
+++ b/peazip-sources/dev/peach.pas
@@ -58268,7 +58268,7 @@ end;
 
 procedure set_rowselect;
 begin
-{$IF DEFINED(LCLQT5) OR DEFINED(LCLQT6)}rowselect:=true;{$ENDIF}//workaround, deselecting first subitem in listview does not deselect the row in Qt5, which leads to behavior of the component which is not consistent with oter widget.sets
+{$IF DEFINED(LCLQT5) OR DEFINED(LCLQT6)}rowselect:=true;{$ENDIF}//workaround, deselecting first subitem in listview does not deselect the row in Qt5 and Qt6, which leads to behavior of the component which is not consistent with oter widget.sets
 Form_peach.ListView1.Rowselect:=rowselect;
 Form_peach.mrowselect.checked:=rowselect;
 Form_peach.pmrow.checked:=rowselect;
@@ -75294,7 +75294,7 @@ begin
    {$ELSE}
    //Linux notes about TListView
    //GTK2 changing to vsIcon workaround is needed to correctly load small and large icons
-   //Qt4 and Qt5 the workaround is disabled as with tested Lazarus/PFC versions it crashes chaging at runtime back to vsReport (which is default visual style), this bug also breaks changing visual style back to default vsReport at runtime for Qt versions
+   //Qt4, Qt5 and Qt6 the workaround is disabled as with tested Lazarus/PFC versions it crashes chaging at runtime back to vsReport (which is default visual style), this bug also breaks changing visual style back to default vsReport at runtime for Qt versions
    {$IFDEF LCLQT}
    {$ELSE}
       {$IF DEFINED(LCLQT5) OR DEFINED(LCLQT6)}

--- a/peazip-sources/readme.txt
+++ b/peazip-sources/readme.txt
@@ -81,7 +81,7 @@ This extra step is due to Lazarus architecture in which packages belongs to the 
 Windows-only:
 
 (peazip sources)/dev/dragdropfilesdll subdirectory contains sources to build dragdropfilesdll.dll, which provides application-to-system files drag&drop functions under Windows systems
-It requires installation of optional Lazarus package DragDropLazarus5.2 (or newer) to be compiled, which is based on work of Angus Johnson & Anders Melander (on Delphi), and Michael Köcher / six (on Lazarus);  the package is available in Lazarus Online Package Manager or from https://packages.lazarus-ide.org/DragDrop.zip
+It requires installation of optional Lazarus package DragDropLazarus5.2 (or newer) to be compiled, which is based on work of Angus Johnson & Anders Melander (on Delphi), and Michael Kï¿½cher / six (on Lazarus);  the package is available in Lazarus Online Package Manager or from https://packages.lazarus-ide.org/DragDrop.zip
 
 IMPORTANT: dragdropfilesdll.dll SHA256 is checked by PeaZip for Windows on startup in procedure internaldllcheck, in order to assure the dll matches with a known whitelisted hash value to prevent DLL Hijacking attacks.
 If dragdropfilesdll.dll SHA256 hash does not match with the value hardcoded in procedure internaldllcheck, PeaZip will halt displaying an error message about the dll.
@@ -111,7 +111,7 @@ NAMING
 PeaZip project packages follows this naming convention: name-version.architecture 
 DEB packages are an exception to this rule, following Debian naming convention: name_version_architecture
 "name" states the pakage (i.e. PeaZip, PeaZip Portable, sources...)
-"version" field starts with version number x.y.z, then states target OS (LINUX, WINDOWS, WIN64); on Linux systems is then declared the target widgetset (i.e. GKT2, Qt5), and finally the release number (usually -1).
+"version" field starts with version number x.y.z, then states target OS (LINUX, WINDOWS, WIN64); on Linux systems is then declared the target widgetset (i.e. GKT2, Qt5, Qt6), and finally the release number (usually -1).
 "architecture" on Linux declare target architecture (on Debian amd64 is used in place of x86_64) and is omitted on Windows.
 
 PORTABLE PACKAGES

--- a/peazip-sources/res/share/readme/readme_Linux.txt
+++ b/peazip-sources/res/share/readme/readme_Linux.txt
@@ -37,5 +37,5 @@ PeaZip is developed in FreePascal using Lazarus development environment; to comp
 
 QT VERSION
 
-Qt widgetset packages requires Qt5 (Qt 4.3 for legacy 32 bit Linux packages), and needs libQt5Pas.so.1.2.6 often referred as libQt5Pas.so.1 (libqt4intf.so and libqt4pas5 for 32 bit) or equivalent binary installed in /usr/local/lib or equivalent directory, such as /usr/lib or /usr/lib32.
+Qt widgetset packages requires Qt5 or Qt6 (Qt 4.3 for legacy 32 bit Linux packages), and needs libQt5Pas.so.1.2.6/libQt6Pas.so.6.2.7 often referred as libQt5Pas.so.1/libQt6Pas.so.6 (libqt4intf.so and libqt4pas5 for 32 bit) or equivalent binary installed in /usr/local/lib or equivalent directory, such as /usr/lib or /usr/lib32.
 You can get up to date missing libraries using distribution-specific ways, i.e. apt-get install package:architecture, or copy the file manually and run ldconfig


### PR DESCRIPTION
Kde 6's default qt version is qt6 now, so many packages using lazrus have added a version for qt6, this pr allows building against qt6 using `--widgetset=qt6`.