### PR TITLE
Do not use asm implementations on non-x86

### DIFF
--- a/peazip-sources/dev/bcrc64.pas
+++ b/peazip-sources/dev/bcrc64.pas
@@ -115,7 +115,7 @@ implementation
 
 
 {$ifdef FPC}
-  {$if defined(CPUARM) or defined(CPUAARCH64)}
+  {$ifndef PurePascal}
     {$asmmode intel}
   {$endif}
 {$endif}

--- a/peazip-sources/dev/rmd160.pas
+++ b/peazip-sources/dev/rmd160.pas
@@ -126,7 +126,7 @@ implementation
 
 
 {$ifdef FPC}
-  {$if not(defined(CPUARM)) and not(defined(CPUAARCH64))}
+  {$ifndef PurePascal}
     {$asmmode intel}
   {$endif}
 {$endif}

--- a/peazip-sources/dev/std.inc
+++ b/peazip-sources/dev/std.inc
@@ -512,6 +512,10 @@
   {$endif}
   {$ifdef CPUARM}
     {$define EXT64}       {No extended for ARM}
+  {$endif}
+
+  {Do not use asm implementations on non-x86 platforms}
+  {$if not(defined(CPU86) or defined(CPU87) or defined(CPU386) or defined(CPUI386) or defined(CPUX86_64) or defined(CPUAMD64) or defined(CPUX64))}
     {$define PurePascal}
   {$endif}
 {$endif}

--- a/peazip-sources/dev/tsc.pas
+++ b/peazip-sources/dev/tsc.pas
@@ -96,7 +96,7 @@ function  _CheckRDTSC: boolean;
 
 implementation
 
-{$if defined(CPUARM) or defined(CPUAARCH64)}
+{$ifdef PurePascal}
 
 {$ifdef WINCE}
 


### PR DESCRIPTION
Hi. I'm currently trying to get PeaZip packaged for [Fedora Linux](https://fedoraproject.org/). In Fedora, apart from `x86_64`, we also support FPC and Lazarus for `aarch64` (64-bit ARM) and `ppc64le` (PowerPC 64-bit little-endian).

This patch fixes the program trying to use x86 assembly implementations of certain functions when compiling for non-x86 platforms.