### PR TITLE
Move and rename APPLICATION consts

### DIFF
--- a/peazip-sources/dev/externalprograms.pas
+++ b/peazip-sources/dev/externalprograms.pas
@@ -1,0 +1,110 @@
+unit externalprograms;
+
+{$MODE OBJFPC}{$H+}
+
+interface
+
+const
+  APPLICATION1  = 'Pea 1.26 (LGPLv3, Giorgio Tani)';
+
+  {$IFDEF MSWINDOWS}
+  EXEEXT        = '.exe';
+  UNRARNAME     = 'unrar';
+  APPLICATION2  = '7z 25.01 (LGPL, Igor Pavlov), and Tino Reichardt sfx modules and codecs 24.09-v1.5.7-R1 (LGPL)';
+  {$IFDEF WIN64}
+  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 62.5 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
+  {$ELSE}
+  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaq 7.15 [Matt Mahoney et al. (GPL)]';
+  {$ENDIF}
+  APPLICATION4  = 'Strip (GPL, GNU binutils), UPX 3.95 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
+  APPLICATION5  = 'QUAD 1.12 (LGPL) / BALZ 1.15 (Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
+  APPLICATION6  = 'UNACEV2.DLL 2.6.0.0 (royalty-free UNACEV2.DLL license, ACE Compression Software)';
+  APPLICATION7  = 'FreeArc 0.67 alpha (GPL, Bulat Ziganshin)';
+  APPLICATION8  = 'UNRAR 5.21 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal)';
+  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION10 = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  {$ENDIF}
+
+  {$IFDEF LINUX}
+  EXEEXT        = '';
+  UNRARNAME     = 'unrar-nonfree';
+  APPLICATION2  = 'Linux 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
+  APPLICATION10 = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  {$IFDEF CPUAARCH64}
+  APPLICATION3  = '';
+  APPLICATION4  = 'Strip (GPL, GNU binutils)';
+  APPLICATION5  = '';
+  APPLICATION6  = '';
+  APPLICATION7  = '';
+  APPLICATION8  = '';
+  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  {$ELSE}
+  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 59.8 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
+  APPLICATION4  = 'Strip (GPL, GNU binutils), UPX 3.96 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
+  APPLICATION5  = 'QUAD 1.12 (LGPL) / BALZ 1.15(Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
+  APPLICATION6  = 'UNACE (royalty-free UNACE for Linux license, Marcel Lemke, ACE Compression Software)';
+  APPLICATION7  = 'FreeArc 0.60 (GPL, Bulat Ziganshin)';
+  APPLICATION8  = 'UNRAR 5.21 beta 2 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal, Petr Cech)';
+  APPLICATION9  = 'Brotli 1.0.7 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  {$ENDIF}
+  {$ENDIF}
+
+  {$IFDEF FREEBSD}
+  EXEEXT        = '';
+  UNRARNAME     = '';
+  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
+  APPLICATION3  = '';
+  APPLICATION4  = 'Strip (GPL, GNU binutils)';
+  APPLICATION5  = '';
+  APPLICATION6  = '';
+  APPLICATION7  = '';
+  APPLICATION8  = '';
+  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  {$ENDIF}
+
+  {$IFDEF NETBSD}
+  EXEEXT        = '';
+  UNRARNAME     = '';
+  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
+  APPLICATION3  = '';
+  APPLICATION4  = 'Strip (GPL, GNU binutils)';
+  APPLICATION5  = '';
+  APPLICATION6  = '';
+  APPLICATION7  = '';
+  APPLICATION8  = '';
+  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  {$ENDIF}
+
+  {$IFDEF OPENBSD}
+  EXEEXT        = '';
+  UNRARNAME     = '';
+  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
+  APPLICATION3  = '';
+  APPLICATION4  = 'Strip (GPL, GNU binutils)';
+  APPLICATION5  = '';
+  APPLICATION6  = '';
+  APPLICATION7  = '';
+  APPLICATION8  = '';
+  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  {$ENDIF}
+
+  {$IFDEF DARWIN}
+  EXEEXT        = '';
+  UNRARNAME     = '';
+  APPLICATION2  = 'macOS 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
+  APPLICATION3  = 'Zpaqfranz 61.2 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]]';
+  APPLICATION4  = 'Strip (GPL, GNU binutils)';
+  APPLICATION5  = '';
+  APPLICATION6  = '';
+  APPLICATION7  = '';
+  APPLICATION8  = '';
+  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION10 = 'Zstd 1.5.2 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  {$ENDIF}
+
+implementation
+
+end.

--- a/peazip-sources/dev/externalprograms.pas
+++ b/peazip-sources/dev/externalprograms.pas
@@ -5,104 +5,104 @@ unit externalprograms;
 interface
 
 const
-  APPLICATION1  = 'Pea 1.26 (LGPLv3, Giorgio Tani)';
+  APPLICATION_PEA = 'Pea 1.26 (LGPLv3, Giorgio Tani)';
 
   {$IFDEF MSWINDOWS}
   EXEEXT        = '.exe';
   UNRARNAME     = 'unrar';
-  APPLICATION2  = '7z 25.01 (LGPL, Igor Pavlov), and Tino Reichardt sfx modules and codecs 24.09-v1.5.7-R1 (LGPL)';
+  APPLICATION_7Z = '7z 25.01 (LGPL, Igor Pavlov), and Tino Reichardt sfx modules and codecs 24.09-v1.5.7-R1 (LGPL)';
   {$IFDEF WIN64}
-  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 62.5 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
+  APPLICATION_ZPAQ = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 62.5 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
   {$ELSE}
-  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaq 7.15 [Matt Mahoney et al. (GPL)]';
+  APPLICATION_ZPAQ = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaq 7.15 [Matt Mahoney et al. (GPL)]';
   {$ENDIF}
-  APPLICATION4  = 'Strip (GPL, GNU binutils), UPX 3.95 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
-  APPLICATION5  = 'QUAD 1.12 (LGPL) / BALZ 1.15 (Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
-  APPLICATION6  = 'UNACEV2.DLL 2.6.0.0 (royalty-free UNACEV2.DLL license, ACE Compression Software)';
-  APPLICATION7  = 'FreeArc 0.67 alpha (GPL, Bulat Ziganshin)';
-  APPLICATION8  = 'UNRAR 5.21 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal)';
-  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  APPLICATION_STRIP   = 'Strip (GPL, GNU binutils), UPX 3.95 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
+  APPLICATION_QUAD    = 'QUAD 1.12 (LGPL) / BALZ 1.15 (Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
+  APPLICATION_UNACE   = 'UNACEV2.DLL 2.6.0.0 (royalty-free UNACEV2.DLL license, ACE Compression Software)';
+  APPLICATION_FREEARC = 'FreeArc 0.67 alpha (GPL, Bulat Ziganshin)';
+  APPLICATION_UNRAR   = 'UNRAR 5.21 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal)';
+  APPLICATION_BROTLI  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION_ZSTD    = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
   {$ENDIF}
 
   {$IFDEF LINUX}
   EXEEXT        = '';
   UNRARNAME     = 'unrar-nonfree';
-  APPLICATION2  = 'Linux 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
-  APPLICATION10 = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  APPLICATION_7Z   = 'Linux 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
+  APPLICATION_ZSTD = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
   {$IFDEF CPUAARCH64}
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION_ZPAQ    = '';
+  APPLICATION_STRIP   = 'Strip (GPL, GNU binutils)';
+  APPLICATION_QUAD    = '';
+  APPLICATION_UNACE   = '';
+  APPLICATION_FREEARC = '';
+  APPLICATION_UNRAR   = '';
+  APPLICATION_BROTLI  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
   {$ELSE}
-  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 59.8 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
-  APPLICATION4  = 'Strip (GPL, GNU binutils), UPX 3.96 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
-  APPLICATION5  = 'QUAD 1.12 (LGPL) / BALZ 1.15(Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
-  APPLICATION6  = 'UNACE (royalty-free UNACE for Linux license, Marcel Lemke, ACE Compression Software)';
-  APPLICATION7  = 'FreeArc 0.60 (GPL, Bulat Ziganshin)';
-  APPLICATION8  = 'UNRAR 5.21 beta 2 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal, Petr Cech)';
-  APPLICATION9  = 'Brotli 1.0.7 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION_ZPAQ    = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 59.8 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
+  APPLICATION_STRIP   = 'Strip (GPL, GNU binutils), UPX 3.96 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
+  APPLICATION_QUAD    = 'QUAD 1.12 (LGPL) / BALZ 1.15(Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
+  APPLICATION_UNACE   = 'UNACE (royalty-free UNACE for Linux license, Marcel Lemke, ACE Compression Software)';
+  APPLICATION_FREEARC = 'FreeArc 0.60 (GPL, Bulat Ziganshin)';
+  APPLICATION_UNRAR   = 'UNRAR 5.21 beta 2 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal, Petr Cech)';
+  APPLICATION_BROTLI  = 'Brotli 1.0.7 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
   {$ENDIF}
   {$ENDIF}
 
   {$IFDEF FREEBSD}
   EXEEXT        = '';
   UNRARNAME     = '';
-  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  APPLICATION_7Z      = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
+  APPLICATION_ZPAQ    = '';
+  APPLICATION_STRIP   = 'Strip (GPL, GNU binutils)';
+  APPLICATION_QUAD    = '';
+  APPLICATION_UNACE   = '';
+  APPLICATION_FREEARC = '';
+  APPLICATION_UNRAR   = '';
+  APPLICATION_BROTLI  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION_ZSTD    = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
   {$ENDIF}
 
   {$IFDEF NETBSD}
   EXEEXT        = '';
   UNRARNAME     = '';
-  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  APPLICATION_7Z      = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
+  APPLICATION_ZPAQ    = '';
+  APPLICATION_STRIP   = 'Strip (GPL, GNU binutils)';
+  APPLICATION_QUAD    = '';
+  APPLICATION_UNACE   = '';
+  APPLICATION_FREEARC = '';
+  APPLICATION_UNRAR   = '';
+  APPLICATION_BROTLI  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION_ZSTD    = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
   {$ENDIF}
 
   {$IFDEF OPENBSD}
   EXEEXT        = '';
   UNRARNAME     = '';
-  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  APPLICATION_7Z      = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
+  APPLICATION_ZPAQ    = '';
+  APPLICATION_STRIP   = 'Strip (GPL, GNU binutils)';
+  APPLICATION_QUAD    = '';
+  APPLICATION_UNACE   = '';
+  APPLICATION_FREEARC = '';
+  APPLICATION_UNRAR   = '';
+  APPLICATION_BROTLI  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION_ZSTD    = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
   {$ENDIF}
 
   {$IFDEF DARWIN}
   EXEEXT        = '';
   UNRARNAME     = '';
-  APPLICATION2  = 'macOS 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
-  APPLICATION3  = 'Zpaqfranz 61.2 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]]';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.5.2 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
+  APPLICATION_7Z      = 'macOS 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
+  APPLICATION_ZPAQ    = 'Zpaqfranz 61.2 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]]';
+  APPLICATION_STRIP   = 'Strip (GPL, GNU binutils)';
+  APPLICATION_QUAD    = '';
+  APPLICATION_UNACE   = '';
+  APPLICATION_FREEARC = '';
+  APPLICATION_UNRAR   = '';
+  APPLICATION_BROTLI  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
+  APPLICATION_ZSTD    = 'Zstd 1.5.2 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
   {$ENDIF}
 
 implementation

--- a/peazip-sources/dev/peach.pas
+++ b/peazip-sources/dev/peach.pas
@@ -6610,19 +6610,19 @@ Form_peach.Labelabout1.caption:=APPMAIN+' '+txt_release+' '+PEAZIPVERSION+PEAZIP
         +langstrhint+char($0d)+char($0a)
         +char($0d)+char($0a)
         +txt_using+char($0d)+char($0a)
-        +APPLICATION1+char($0d)+char($0a)
-        +APPLICATION2+char($0d)+char($0a)
-        +APPLICATION3+char($0d)+char($0a)
-        +APPLICATION4+char($0d)+char($0a)
-        +APPLICATION5+char($0d)+char($0a)
-        +APPLICATION7+char($0d)+char($0a)
-        +APPLICATION9+char($0d)+char($0a)
-        +APPLICATION10+char($0d)+char($0a)
+        +APPLICATION_PEA+char($0d)+char($0a)
+        +APPLICATION_7Z+char($0d)+char($0a)
+        +APPLICATION_ZPAQ+char($0d)+char($0a)
+        +APPLICATION_STRIP+char($0d)+char($0a)
+        +APPLICATION_QUAD+char($0d)+char($0a)
+        +APPLICATION_FREEARC+char($0d)+char($0a)
+        +APPLICATION_BROTLI+char($0d)+char($0a)
+        +APPLICATION_ZSTD+char($0d)+char($0a)
         +char($0d)+char($0a)
         +'Plugin:'+char($0d)+char($0a)
         +'PeaZip Additional Formats Plugin (LGPLv3) - '+addformatspluginstatus+char($0d)+char($0a)
-        +APPLICATION6+' - '+unacepluginstatus+char($0d)+char($0a)
-        +APPLICATION8+' - '+unrar5pluginstatus+char($0d)+char($0a);
+        +APPLICATION_UNACE+' - '+unacepluginstatus+char($0d)+char($0a)
+        +APPLICATION_UNRAR+' - '+unrar5pluginstatus+char($0d)+char($0a);
 end;
 
 procedure setlabelpanel_options(var a: Tlabel);

--- a/peazip-sources/dev/peach.pas
+++ b/peazip-sources/dev/peach.pas
@@ -5805,7 +5805,6 @@ const
   READE_LIST    = '7Z, ACE, ARC/WRC, ARJ, BR, BZ/TBZ, CAB, CHM/CHW/HXS, COMPOUND (MSI, DOC, XLS, PPT), CPIO, GZ/TGZ, ISO, Java (JAR, EAR, WAR), LZH/LHA, Linux (DEB, PET/PUP, RPM, SLP), NSIS, OOo, PAK/PK3/PK4, PAQ/LPAQ/ZPAQ, PEA, QUAD/BALZ/BCM, RAR, TAR, WIM/SWM, XPI, Z/TZ, ZIP, ZST...';
   WRITEE_LIST   = '7Z, 7Z-sfx, ARC, ARC-sfx, BR, BZ2, GZ, *PAQ, PEA, QUAD/BALZ/BCM, split, TAR, UPX, WIM, XZ, ZIP, ZST';
   APPMAIN       = 'PeaZip';
-  APPLICATION1  = 'Pea 1.26 (LGPLv3, Giorgio Tani)';
   STR_7Z        = '7Z';
   STR_ARC       = 'ARC';
   STR_BROTLI    = 'Brotli';
@@ -5836,98 +5835,6 @@ const
   STR_STOPALL   = '.pstopalltmp';
   STR_TMPDROPE  = '.pdropetmp';
   STR_TMPERRI   = '.perritmp';
-  {$IFDEF MSWINDOWS}
-  EXEEXT        = '.exe';
-  UNRARNAME     = 'unrar';
-  APPLICATION2  = '7z 25.01 (LGPL, Igor Pavlov), and Tino Reichardt sfx modules and codecs 24.09-v1.5.7-R1 (LGPL)';
-  {$IFDEF WIN64}
-  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 62.5 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
-  {$ELSE}
-  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaq 7.15 [Matt Mahoney et al. (GPL)]';
-  {$ENDIF}
-  APPLICATION4  = 'Strip (GPL, GNU binutils), UPX 3.95 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
-  APPLICATION5  = 'QUAD 1.12 (LGPL) / BALZ 1.15 (Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
-  APPLICATION6  = 'UNACEV2.DLL 2.6.0.0 (royalty-free UNACEV2.DLL license, ACE Compression Software)';
-  APPLICATION7  = 'FreeArc 0.67 alpha (GPL, Bulat Ziganshin)';
-  APPLICATION8  = 'UNRAR 5.21 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal)';
-  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
-  {$ENDIF}
-  {$IFDEF LINUX}
-  EXEEXT        = '';
-  UNRARNAME     = 'unrar-nonfree';
-  APPLICATION2  = 'Linux 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
-  APPLICATION10 = 'Zstd 1.5.7 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
-  {$IFDEF CPUAARCH64}
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  {$ELSE}
-  APPLICATION3  = 'PAQ8F/JD/L/O, LPAQ1/5/8, Zpaqfranz 59.8 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]';
-  APPLICATION4  = 'Strip (GPL, GNU binutils), UPX 3.96 (GPL, Markus F.X.J. Oberhumer, Laszlo Molnar and John F. Reiser)';
-  APPLICATION5  = 'QUAD 1.12 (LGPL) / BALZ 1.15(Public Domain), BCM 1.0 (Public Domain) (Ilia Muraviev)';
-  APPLICATION6  = 'UNACE (royalty-free UNACE for Linux license, Marcel Lemke, ACE Compression Software)';
-  APPLICATION7  = 'FreeArc 0.60 (GPL, Bulat Ziganshin)';
-  APPLICATION8  = 'UNRAR 5.21 beta 2 (freeware, royalty-free, source available with unrar restriction, Alexander Roshal, Petr Cech)';
-  APPLICATION9  = 'Brotli 1.0.7 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  {$ENDIF}
-  {$ENDIF}
-  {$IFDEF FREEBSD}
-  EXEEXT        = '';
-  UNRARNAME     = '';
-  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
-  {$ENDIF}
-  {$IFDEF NETBSD}
-  EXEEXT        = '';
-  UNRARNAME     = '';
-  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
-  {$ENDIF}
-  {$IFDEF OPENBSD}
-  EXEEXT        = '';
-  UNRARNAME     = '';
-  APPLICATION2  = 'BSD 7z 21.07 (LGPL, Igor Pavlov)';
-  APPLICATION3  = '';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.0.9 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.4.8 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
-  {$ENDIF}
-  {$IFDEF DARWIN}
-  EXEEXT        = '';
-  UNRARNAME     = '';
-  APPLICATION2  = 'macOS 7z 25.01 (LGPL, Igor Pavlov), cielavenir/p7zip 24.09.1 (LGPL, T. Yamada)';
-  APPLICATION3  = 'Zpaqfranz 61.2 [Matt Mahoney et al. (GPL), Franco Corbelli (Mit)]]';
-  APPLICATION4  = 'Strip (GPL, GNU binutils)';
-  APPLICATION5  = '';
-  APPLICATION6  = '';
-  APPLICATION7  = '';
-  APPLICATION8  = '';
-  APPLICATION9  = 'Brotli 1.1.0 (MIT License, Jyrki Alakuijala, Eugene Kliuchnikov, Robert Obryk, Zoltán Szabadka, Lode Vandevenne)';
-  APPLICATION10 = 'Zstd 1.5.2 (Dual license BSD / GPLv2, Yann Collet, Przemysław Skibiński)';
-  {$ENDIF}
 
 var
    Form_peach: TForm_peach;
@@ -6361,6 +6268,9 @@ var
    txt_searchfor,txt_websearch,txt_on,txt_convert:ansistring;
 
 implementation
+
+uses
+  externalprograms;
 
 { TForm_peach }
 


### PR DESCRIPTION
This PR moves `APPLICATION*` consts to a separate unit file and gives them more descriptive names.

My long-term idea with this is to introduce some kind of class for representing external programs. This class could provide methods for detecting if the program is installed, getting a description, creating the command-line arguments, and so on. Then, existing code could be tidied up a little by moving relevant bits out of `peach.pas` into appropriate sub-classes.