### PR TITLE
Add inode/directory mimetype to KDE6 dolphin desktop files

### DIFF
--- a/peazip-sources/res/share/batch/freedesktop_integration/KDE-servicemenus/KDE6-dolphin/peazip-kde6-minimal.desktop
+++ b/peazip-sources/res/share/batch/freedesktop_integration/KDE-servicemenus/KDE6-dolphin/peazip-kde6-minimal.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Service
-MimeType=application/octet-stream
+MimeType=application/octet-stream;inode/directory
 Actions=peazipadd;peazipext;peazipexthere;peazipextfolder;peazipopen;
 X-KDE-Submenu=PeaZip
 X-KDE-Priority=TopLevel

--- a/peazip-sources/res/share/batch/freedesktop_integration/KDE-servicemenus/KDE6-dolphin/peazip-kde6.desktop
+++ b/peazip-sources/res/share/batch/freedesktop_integration/KDE-servicemenus/KDE6-dolphin/peazip-kde6.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Service
-MimeType=application/octet-stream
+MimeType=application/octet-stream;inode/directory
 Actions=peazipadd;peazipadd7z;peazipaddgzip;peazipaddzip;peazipconvert;peazipext;peazipexthere;peazipextfolder;peazipopen;
 X-KDE-Submenu=PeaZip
 X-KDE-Priority=TopLevel


### PR DESCRIPTION
Hello. This PR adds `inode/directory` mime-type to `KDE6-dolphin/peazip-kde6.desktop` and `KDE6-dolphin/peazip-kde6-minimal.desktop` files to show the context menu items if the user selects a directory. Before this, the PeaZip menu was only visible if the user selected a file.

<img width="709" height="646" alt="image" src="https://github.com/user-attachments/assets/2b05a1ab-22b0-4f69-9970-96a8c57d77d4" />
