### PR TITLE
Fix Nautilus context-menu scripts on Nautilus 46 (GTK4)

### DIFF
--- a/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Add to Archive
+++ b/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Add to Archive
@@ -11,6 +11,12 @@ MESSAGE="Could not find the $APPLICATION executable."
 
 if which peazip 2> /dev/null
 then
+	if [ -n "$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS" ]; then
+		IFS='
+'
+		set -- $NAUTILUS_SCRIPT_SELECTED_FILE_PATHS
+		unset IFS
+	fi
 	peazip -add2archive "$@"
 else
 	# Show an error message

--- a/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Convert
+++ b/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Convert
@@ -11,6 +11,12 @@ MESSAGE="Could not find the $APPLICATION executable."
 
 if which peazip 2> /dev/null
 then
+	if [ -n "$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS" ]; then
+		IFS='
+'
+		set -- $NAUTILUS_SCRIPT_SELECTED_FILE_PATHS
+		unset IFS
+	fi
 	peazip -add2convert "$@"
 else
 	# Show an error message

--- a/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Extract Archive
+++ b/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Extract Archive
@@ -11,6 +11,12 @@ MESSAGE="Could not find the $APPLICATION executable."
 
 if which peazip 2> /dev/null
 then
+	if [ -n "$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS" ]; then
+		IFS='
+'
+		set -- $NAUTILUS_SCRIPT_SELECTED_FILE_PATHS
+		unset IFS
+	fi
 	peazip -ext2main "$@"
 else
 	# Show an error message

--- a/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Extract Here
+++ b/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Extract Here
@@ -11,6 +11,12 @@ MESSAGE="Could not find the $APPLICATION executable."
 
 if which peazip 2> /dev/null
 then
+	if [ -n "$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS" ]; then
+		IFS='
+'
+		set -- $NAUTILUS_SCRIPT_SELECTED_FILE_PATHS
+		unset IFS
+	fi
 	peazip -ext2here "$@"
 else
 	# Show an error message

--- a/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Extract to New Folder
+++ b/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Extract to New Folder
@@ -11,6 +11,12 @@ MESSAGE="Could not find the $APPLICATION executable."
 
 if which peazip 2> /dev/null
 then
+	if [ -n "$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS" ]; then
+		IFS='
+'
+		set -- $NAUTILUS_SCRIPT_SELECTED_FILE_PATHS
+		unset IFS
+	fi
 	peazip -ext2folder "$@"
 else
 	# Show an error message

--- a/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Open Archive
+++ b/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Open Archive
@@ -11,6 +11,12 @@ MESSAGE="Could not find the $APPLICATION executable."
 
 if which peazip 2> /dev/null
 then
+	if [ -n "$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS" ]; then
+		IFS='
+'
+		set -- $NAUTILUS_SCRIPT_SELECTED_FILE_PATHS
+		unset IFS
+	fi
 	peazip -ext2openasarchive "$@"
 else
 	# Show an error message

--- a/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Test
+++ b/peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/Test
@@ -11,6 +11,12 @@ MESSAGE="Could not find the $APPLICATION executable."
 
 if which peazip 2> /dev/null
 then
+	if [ -n "$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS" ]; then
+		IFS='
+'
+		set -- $NAUTILUS_SCRIPT_SELECTED_FILE_PATHS
+		unset IFS
+	fi
 	peazip -ext2test "$@"
 else
 	# Show an error message


### PR DESCRIPTION
## Problem

On Nautilus 46 (GTK4 rewrite), the bundled Nautilus scripts under
`peazip-sources/res/share/batch/freedesktop_integration/Nautilus-scripts/PeaZip/`
open PeaZip with nothing selected: 0 files/folders, output path
defaulting to `$HOME`.

Root cause: Nautilus 46 passes scripts only the bare selected filename
as `$@` (e.g. `Capturas de ecrã`), not a resolvable path, and does not
run the script with its cwd set to the browsed folder. So `peazip
-add2archive "$@"` receives an argument that resolves to nothing.

Confirmed via a script dumping argv and env vars: `$@` held only the
basename, while `$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS` correctly held
the full absolute path the whole time.

## Fix

All 7 scripts (Add to Archive, Convert, Extract Archive, Extract Here,
Extract to New Folder, Open Archive, Test) now prefer
`$NAUTILUS_SCRIPT_SELECTED_FILE_PATHS` (newline-separated absolute
paths, always set by Nautilus) when present, falling back to `"$@"`
for direct/non-Nautilus invocation so behavior is unchanged elsewhere.

Tested on Zorin OS (Nautilus 46.4) - Add to Archive now correctly
pre-fills the target file/folder and suggested output name.